### PR TITLE
Update MParticlePackage.java to support React Native 0.47+

### DIFF
--- a/android/src/main/java/com/mparticle/react/MParticlePackage.java
+++ b/android/src/main/java/com/mparticle/react/MParticlePackage.java
@@ -21,7 +21,6 @@ public class MParticlePackage implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/mparticle/react/MParticlePackage.java
+++ b/android/src/main/java/com/mparticle/react/MParticlePackage.java
@@ -20,7 +20,8 @@ public class MParticlePackage implements ReactPackage {
 
         return modules;
     }
-
+    
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native module for mParticle",
   "homepage": "https://www.mparticle.com",
   "license": "Apache 2.0",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "js/index.js",
   "scripts": {
     "test": "./node_modules/standard/bin/cmd.js",

--- a/sample/android/app/src/main/java/com/mparticlesample/MainApplication.java
+++ b/sample/android/app/src/main/java/com/mparticlesample/MainApplication.java
@@ -19,7 +19,7 @@ public class MainApplication extends Application implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
     @Override
-    protected boolean getUseDeveloperSupport() {
+    public boolean getUseDeveloperSupport() {
       return BuildConfig.DEBUG;
     }
 

--- a/sample/package.json
+++ b/sample/package.json
@@ -7,14 +7,14 @@
 		"test": "jest"
 	},
 	"dependencies": {
-		"react": "~15.4.0-rc.4",
-		"react-native": "0.40.0"
+		"react": "~16.0.0",
+		"react-native": "0.50.0"
 	},
 	"devDependencies": {
 		"babel-jest": "18.0.0",
 		"babel-preset-react-native": "1.9.1",
 		"jest": "18.1.0",
-		"react-test-renderer": "~15.4.0-rc.4"
+		"react-test-renderer": "~16.0.0"
 	},
 	"jest": {
 		"preset": "react-native"


### PR DESCRIPTION
Breaking change in RN 0.47 requires the removal of all overrides of ‘createJSModules’

https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8