### PR TITLE
Adds react-native-mparticle.podspec

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://www.mparticle.com",
   "license": "Apache-2.0",
   "repository": "mParticle/react-native-mparticle",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "js/index.js",
   "scripts": {
     "test": "./node_modules/standard/bin/cmd.js",

--- a/react-native-mparticle.podspec
+++ b/react-native-mparticle.podspec
@@ -1,0 +1,20 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+
+  s.author            = { "mParticle" => "support@mparticle.com" }
+
+  s.homepage     = package['homepage']
+  s.license      = package['license']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/mParticle/react-native-mparticle.git", :tag => "#{s.version}" }
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
To be able to integrate react-native-mparticle with existing app using Podfile instead of adding library to xcode project we need react-native-mparticle.podspec

usage example:
```
pod 'react-native-mparticle', :path => '../node_modules/react-native-mparticle/react-native-mparticle.podspec'
```