### PR TITLE
Fix for: Android Configuration 'provided' is obsolete

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,7 +36,7 @@ repositories {
 }
 
 dependencies {
-    provided 'com.facebook.react:react-native:+'
+    compileOnly 'com.facebook.react:react-native:+'
 
     //
     // In your app, you should include mParticle core like this:
@@ -45,7 +45,7 @@ dependencies {
     //
     // (See https://github.com/mparticle/mparticle-android-sdk for the latest version)
     //
-    provided 'com.mparticle:android-core:5+'
+    compileOnly 'com.mparticle:android-core:5+'
 
     //
     // And, if you want to include kits, you can do so as follows:


### PR DESCRIPTION
Fix for: 
Configuration 'provided' is obsolete and has been replaced with 'compileOnly'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
