### PR TITLE
Add @ReactMethod decorator to getSession method

### DIFF
--- a/android/src/main/java/com/mparticle/react/MParticleModule.java
+++ b/android/src/main/java/com/mparticle/react/MParticleModule.java
@@ -294,6 +294,7 @@ public class MParticleModule extends ReactContextBaseJavaModule {
         }
     }
 
+    @ReactMethod
     public void getSession(Callback completion) {
         String sessionID = MParticle.getInstance().getCurrentSession().getSessionUUID();
         completion.invoke(sessionID);


### PR DESCRIPTION
👋 Since the @ReactMethod decorator is not present on getSession method, it's not usable on Android environment.