### PR TITLE
Implement null check for session on iOS

### DIFF
--- a/ios/RNMParticle/RNMParticle.m
+++ b/ios/RNMParticle/RNMParticle.m
@@ -310,7 +310,7 @@ RCT_EXPORT_METHOD(getLastSeen:(NSString *)userId completion:(RCTResponseSenderBl
 RCT_EXPORT_METHOD(getSession:(RCTResponseSenderBlock)completion)
 {
     MParticleSession *session = [MParticle sharedInstance].currentSession;
-    if (session) {
+    if (session && session.UUID) {
         completion(@[session.UUID]);
     } else {
         completion(@[[NSNull null]]);

--- a/ios/RNMParticle/RNMParticle.m
+++ b/ios/RNMParticle/RNMParticle.m
@@ -309,8 +309,12 @@ RCT_EXPORT_METHOD(getLastSeen:(NSString *)userId completion:(RCTResponseSenderBl
 
 RCT_EXPORT_METHOD(getSession:(RCTResponseSenderBlock)completion)
 {
-    NSString *sessionID = [MParticle sharedInstance].currentSession.UUID;
-    completion(@[sessionID]);
+    MParticleSession *session = [MParticle sharedInstance].currentSession;
+    if (session) {
+        completion(@[session.UUID]);
+    } else {
+        completion(@[[NSNull null]]);
+    }
 }
 
 @end


### PR DESCRIPTION
Hi team! 

I've seen that you've implemented [a null check for the session object in Android](https://github.com/mParticle/react-native-mparticle/commit/beb21f1cfae382656388489a8d9b8c5d54ede512) but [it's missing on iOS](https://github.com/mParticle/mparticle-apple-sdk/blob/master/mParticle-Apple-SDK/mParticle.m#L646-L661).

We have seen some crash reports on iOS regarding that so I thought it'd be nice to fix this.