### PR TITLE
Fix Nullabity Issue for ATT Timestamp

### DIFF
--- a/ios/RNMParticle/RNMParticle.m
+++ b/ios/RNMParticle/RNMParticle.m
@@ -39,9 +39,14 @@ RCT_EXPORT_METHOD(logScreenEvent:(NSString *)screenName attributes:(NSDictionary
     [[MParticle sharedInstance] logScreen:screenName eventInfo:attributes];
 }
 
-RCT_EXPORT_METHOD(setATTStatus:(NSInteger)status withATTStatusTimestampMillis:(NSNumber *)timestamp)
+RCT_EXPORT_METHOD(setATTStatus:(NSInteger)status withATTStatusTimestampMillis:(nonnull NSNumber *)timestamp)
 {
     [[MParticle sharedInstance] setATTStatus:status withATTStatusTimestampMillis:timestamp];
+}
+
+RCT_EXPORT_METHOD(setATTStatus:(NSInteger)status)
+{
+    [[MParticle sharedInstance] setATTStatus:status withATTStatusTimestampMillis:nil];
 }
 
 RCT_EXPORT_METHOD(setOptOut:(BOOL)optOut)

--- a/js/index.js
+++ b/js/index.js
@@ -101,7 +101,11 @@ const logScreenEvent = (screenName, attributes = null) => {
 }
 
 // Use ATTAuthStatus constants for status
-const setATTStatus = (status, timestamp = null) => {
+const setATTStatus = (status) => {
+  NativeModules.MParticle.setATTStatus(status)
+}
+
+const setATTStatusWithCustomTimestamp = (status, timestamp) => {
   NativeModules.MParticle.setATTStatus(status, timestamp)
 }
 
@@ -651,6 +655,7 @@ const MParticle = {
   logCommerceEvent,
   logScreenEvent,
   setATTStatus,
+  setATTStatusWithCustomTimestamp,
   setOptOut,
   getOptOut,
   addGDPRConsentState,


### PR DESCRIPTION
## Summary
When trying to set ATT status on a React Native implementation timestamp can not be set as null for casting reasons to Android. Added separate methods for setting with or without a timestamp.

