### PR TITLE
Correct Casing in SetUserAttribute js method

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -161,7 +161,7 @@ class User {
 
   setUserAttribute (key, value) {
     if (value && value.constructor === Array) {
-      NativeModules.Mparticle.setUserAttributeArray(this.userId, key, value)
+      NativeModules.MParticle.setUserAttributeArray(this.userId, key, value)
     } else {
       NativeModules.MParticle.setUserAttribute(this.userId, key, value)
     }


### PR DESCRIPTION
## Summary
This is to correct a casing issue in the SetUserAttribute js method, which caused the following error
`TypeError: null is not an object (evaluating '_reactNative.NativeModules.Mparticle.setUserAttributeArray')`

## Testing Plan
This was tested locally and confirmed that the corrected casing addressed the issue. 

## Master Issue
Closes https://go.mparticle.com/work/64134
