### PR TITLE
feat: add support for custom attributes in ecommerce events

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,10 @@ MParticle.logEvent('Test event', MParticle.EventType.Other, { 'Test key': 'Test 
 ```js
 const product = new MParticle.Product('Test product for cart', '1234', 19.99)
 const transactionAttributes = new MParticle.TransactionAttributes('Test transaction id')
-const event = MParticle.CommerceEvent.createProductActionEvent(MParticle.ProductActionType.AddToCart, [product], transactionAttributes)
+const customAttributes = {
+    myCustomAttribute: 'value',
+}
+const event = MParticle.CommerceEvent.createProductActionEvent(MParticle.ProductActionType.AddToCart, [product], transactionAttributes, customAttributes)
 
 MParticle.logCommerceEvent(event)
 ```

--- a/android/src/main/java/com/mparticle/react/MParticleModule.java
+++ b/android/src/main/java/com/mparticle/react/MParticleModule.java
@@ -544,6 +544,11 @@ public class MParticleModule extends ReactContextBaseJavaModule {
         }
 
         CommerceEvent.Builder builder = null;
+        Map customAttributes = null;
+
+        if (map.hasKey("customAttributes")) {
+            customAttributes = map.getMap("customAttributes").toHashMap();
+        }
 
         if (isProductAction) {
             int productActionInt = map.getInt("productActionType");
@@ -553,7 +558,7 @@ public class MParticleModule extends ReactContextBaseJavaModule {
             Product product = ConvertProduct(productMap);
             ReadableMap transactionAttributesMap = map.getMap("transactionAttributes");
             TransactionAttributes transactionAttributes = ConvertTransactionAttributes(transactionAttributesMap);
-            builder = new CommerceEvent.Builder(productAction, product).transactionAttributes(transactionAttributes);
+            builder = new CommerceEvent.Builder(productAction, product).transactionAttributes(transactionAttributes).customAttributes(customAttributes);
 
             for (int i = 1; i < productsArray.size(); ++i) {
                 productMap = productsArray.getMap(i);
@@ -567,7 +572,7 @@ public class MParticleModule extends ReactContextBaseJavaModule {
             ReadableArray promotionsReadableArray = map.getArray("promotions");
             ReadableMap promotionMap = promotionsReadableArray.getMap(0);
             Promotion promotion = ConvertPromotion(promotionMap);
-            builder = new CommerceEvent.Builder(promotionAction, promotion);
+            builder = new CommerceEvent.Builder(promotionAction, promotion).customAttributes(customAttributes);
 
             for (int i = 0; i < promotionsReadableArray.size(); ++i) {
                 promotionMap = promotionsReadableArray.getMap(i);
@@ -579,7 +584,7 @@ public class MParticleModule extends ReactContextBaseJavaModule {
             ReadableArray impressionsArray = map.getArray("impressions");
             ReadableMap impressionMap = impressionsArray.getMap(0);
             Impression impression = ConvertImpression(impressionMap);
-            builder = new CommerceEvent.Builder(impression);
+            builder = new CommerceEvent.Builder(impression).customAttributes(customAttributes);
 
             for (int i = 0; i < impressionsArray.size(); ++i) {
                 impressionMap = impressionsArray.getMap(i);

--- a/ios/RNMParticle/RNMParticle.m
+++ b/ios/RNMParticle/RNMParticle.m
@@ -416,6 +416,7 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
     commerceEvent.action = [RCTConvert MPCommerceEventAction:json[@"productActionType"]];
     commerceEvent.checkoutStep = [json[@"checkoutStep"] intValue];
     commerceEvent.nonInteractive = [json[@"nonInteractive"] boolValue];
+    commerceEvent.customAttributes = json[@"customAttributes"];
 
     NSMutableArray *products = [NSMutableArray array];
     NSArray *jsonProducts = json[@"products"];

--- a/js/index.js
+++ b/js/index.js
@@ -479,10 +479,11 @@ class CCPAConsent {
 
 class CommerceEvent {
 
-  static createProductActionEvent (productActionType, products, transactionAttributes = {}) {
+  static createProductActionEvent (productActionType, products, transactionAttributes = {}, customAttributes = {}) {
     return new CommerceEvent()
                     .setProductActionType(productActionType)
                     .setProducts(products)
+                    .setCustomAttributes(customAttributes)
                     .setTransactionAttributes(transactionAttributes)
   }
 


### PR DESCRIPTION
## Summary

This PR adds ecommerce `customAttributes` support.
This is a **Breaking Change**

## Testing Plan

```js
const product = new MParticle.Product('Test product for cart', '1234', 19.99)
const transactionAttributes = new MParticle.TransactionAttributes('Test transaction id')
const customAttributes = {
  myCustomAttribute: 'value',
}
const event = MParticle.CommerceEvent.createProductActionEvent(MParticle.ProductActionType.AddToCart, [product], transactionAttributes, customAttributes)

MParticle.logCommerceEvent(event)
```

fixes #21