### PR TITLE
feat: Add shouldUploadEventCommerce Event Support for Android and iOS

### DIFF
--- a/android/src/main/java/com/mparticle/react/MParticleModule.java
+++ b/android/src/main/java/com/mparticle/react/MParticleModule.java
@@ -508,6 +508,10 @@ public class MParticleModule extends ReactContextBaseJavaModule {
                 }
             }
 
+            if (map.hasKey("shouldUploadEvent")) {
+                builder.shouldUploadEvent(map.getBoolean("shouldUploadEvent"));
+            }
+
             return  builder.build();
         }
 
@@ -586,6 +590,10 @@ public class MParticleModule extends ReactContextBaseJavaModule {
                 impression = ConvertImpression(impressionMap);
                 builder.addImpression(impression);
             }
+        }
+
+        if (map.hasKey("shouldUploadEvent")) {
+            builder.shouldUploadEvent(map.getBoolean("shouldUploadEvent"));
         }
 
         return builder.build();

--- a/ios/RNMParticle/RNMParticle.m
+++ b/ios/RNMParticle/RNMParticle.m
@@ -416,8 +416,8 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
     commerceEvent.action = [RCTConvert MPCommerceEventAction:json[@"productActionType"]];
     commerceEvent.checkoutStep = [json[@"checkoutStep"] intValue];
     commerceEvent.nonInteractive = [json[@"nonInteractive"] boolValue];
-    if json["shouldUploadEvent"] != nil {
-        event.shouldUploadEvent = [json["shouldUploadEvent"] boolValue]
+    if json[@"shouldUploadEvent"] != nil {
+        event.shouldUploadEvent = [json[@"shouldUploadEvent"] boolValue]
     }
 
     NSMutableArray *products = [NSMutableArray array];
@@ -605,8 +605,8 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
     event.name = json[@"name"];
     event.startTime = json[@"startTime"];
     event.type = [json[@"type"] intValue];
-    if json["shouldUploadEvent"] != nil {
-        event.shouldUploadEvent = [json["shouldUploadEvent"] boolValue]
+    if json[@"shouldUploadEvent"] != nil {
+        event.shouldUploadEvent = [json[@"shouldUploadEvent"] boolValue]
     }
 
     NSDictionary *jsonFlags = json[@"customFlags"];

--- a/ios/RNMParticle/RNMParticle.m
+++ b/ios/RNMParticle/RNMParticle.m
@@ -416,6 +416,9 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
     commerceEvent.action = [RCTConvert MPCommerceEventAction:json[@"productActionType"]];
     commerceEvent.checkoutStep = [json[@"checkoutStep"] intValue];
     commerceEvent.nonInteractive = [json[@"nonInteractive"] boolValue];
+    if json["shouldUploadEvent"] != nil {
+        event.shouldUploadEvent = [json["shouldUploadEvent"] boolValue]
+    }
 
     NSMutableArray *products = [NSMutableArray array];
     NSArray *jsonProducts = json[@"products"];
@@ -602,6 +605,9 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
     event.name = json[@"name"];
     event.startTime = json[@"startTime"];
     event.type = [json[@"type"] intValue];
+    if json["shouldUploadEvent"] != nil {
+        event.shouldUploadEvent = [json["shouldUploadEvent"] boolValue]
+    }
 
     NSDictionary *jsonFlags = json[@"customFlags"];
     for (NSString *key in jsonFlags) {

--- a/js/index.js
+++ b/js/index.js
@@ -566,6 +566,11 @@ class CommerceEvent {
     this.nonInteractive = nonInteractive
     return this
   }
+
+  setShouldUploadEvent (shouldUploadEvent) {
+    this.shouldUploadEvent = shouldUploadEvent
+    return this
+  }
 }
 
 class Event {
@@ -602,6 +607,11 @@ class Event {
 
   setType (type) {
     this.type = type
+    return this
+  }
+
+  setShouldUploadEvent (shouldUploadEvent) {
+    this.shouldUploadEvent = shouldUploadEvent
     return this
   }
 


### PR DESCRIPTION
## Summary
We added the upload bypass option for events (shouldUploadEvent property) in the core iOS and Android SDKs, which has now been released. This work adds the option to the React Native SDK.

## Testing Plan
Ran on sample app and confirmed with live stream

## Master Issue
TP: 69766
