### PR TITLE
Fix: Boolean map customAttribute values crash on Android

### DIFF
--- a/android/src/main/java/com/mparticle/react/MParticleModule.java
+++ b/android/src/main/java/com/mparticle/react/MParticleModule.java
@@ -716,7 +716,34 @@ public class MParticleModule extends ReactContextBaseJavaModule {
             ReadableMapKeySetIterator iterator = readableMap.keySetIterator();
             while (iterator.hasNextKey()) {
                 String key = iterator.nextKey();
-                map.put(key, readableMap.getString(key));
+                switch (readableMap.getType(key)) {
+                    case Null:
+                        map.put(key, null);
+                        break;
+                    case Boolean:
+                        map.put(key, Boolean.valueOf(readableMap.getBoolean(key)).toString());
+                        break;
+                    case Number:
+                        try {
+                            map.put(key, Integer.toString(readableMap.getInt(key)));
+                        } catch (Exception e) {
+                            try {
+                                map.put(key, Double.toString(readableMap.getDouble(key)));
+                            } catch (Exception ex) {
+                                Logger.warning("Unable to parse value for \"" + key + "\"");
+                            }
+                        }
+                        break;
+                    case String:
+                        map.put(key, readableMap.getString(key));
+                        break;
+                    case Map:
+                        Logger.warning("Maps are not supported Attribute value types");
+                        break;
+                    case Array:
+                        Logger.warning("Lists are not supported Attribute value types");
+                        break;
+                }
             }
         }
 

--- a/sample/android/app/build.gradle
+++ b/sample/android/app/build.gradle
@@ -126,10 +126,9 @@ android {
 }
 
 dependencies {
-    compile project(':react-native-mparticle')
-    compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:28+"
-    compile "com.facebook.react:react-native:+"  // From node_modules
+    implementation project(':react-native-mparticle')
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation "com.facebook.react:react-native:+"  // From node_modules
 
     //
     // In your app, you should include mParticle core like this:
@@ -138,7 +137,7 @@ dependencies {
     //
     // (See https://github.com/mparticle/mparticle-android-sdk for the latest version)
     //
-    compile "com.mparticle:android-core:5.+"
+    implementation "com.mparticle:android-core:5.+"
 
     //
     // And, if you want to include kits, you can do so as follows:

--- a/sample/android/app/src/main/java/com/mparticlesample/MainApplication.java
+++ b/sample/android/app/src/main/java/com/mparticlesample/MainApplication.java
@@ -48,7 +48,7 @@ public class MainApplication extends Application implements ReactApplication {
     IdentityApiRequest.Builder identityRequest = IdentityApiRequest.withEmptyUser();
 
     MParticleOptions options = MParticleOptions.builder(this)
-      .credentials("REPLACE ME WITH KEY","REPLACE ME WITH SECRET")
+      .credentials("us1-352af4d005e49047a7bcc78281f33e9c","flR34mIajnAA5F-Ouha7JQF5v0JqFUfo_QjJtM_16VESU2hS0ikp3hRILG70-aBk")
       .logLevel(MParticle.LogLevel.VERBOSE)
       .identify(identityRequest.build())
       .build();

--- a/sample/index.android.js
+++ b/sample/index.android.js
@@ -86,7 +86,7 @@ export default class MParticleSample extends Component {
     var i = 0;
     // Toggle the state every few seconds, 10 times
     var intervalId = setInterval(() => {
-        MParticle.logEvent('Test event', MParticle.EventType.Other, { 'Test key': 'Test value' })
+        MParticle.logEvent('Test event', MParticle.EventType.Other, { 'Test key': 'Test value', 'Test Boolean': true, 'Test Int': 1235, 'Test Double': 123.123 })
         this.setState((previousState) => {
           return {isShowingText: !previousState.isShowingText}
         })


### PR DESCRIPTION
## Summary
A public issue was opened indicating that custom attribute instances containing Boolean keys were crashing in the Android layer. I tested and confirmed this was the case and observed a similar crash with Double and Integers. Even though we only accept String values in the native SDKS, since we don't have any way of enforcing this in vanilla JS, it makes sense to handle this case and stringify the values rather than rejecting them 

## Testing Plan
Added Boolean and number cases to our sample app and smoke tested...test improvements have been a long time coming on this project but it seemed like too big of a lift for this ticket

## Master Issue
Public Issue: https://github.com/mParticle/react-native-mparticle/issues/45
Closes https://go.mparticle.com/work/71487
