### PR TITLE
Fix syntax errors for the latest React Native release

### DIFF
--- a/ios/RNMParticle/RNMParticle.m
+++ b/ios/RNMParticle/RNMParticle.m
@@ -417,7 +417,7 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
     commerceEvent.checkoutStep = [json[@"checkoutStep"] intValue];
     commerceEvent.nonInteractive = [json[@"nonInteractive"] boolValue];
     if (json[@"shouldUploadEvent"] != nil) {
-        event.shouldUploadEvent = [json[@"shouldUploadEvent"] boolValue]
+        commerceEvent.shouldUploadEvent = [json[@"shouldUploadEvent"] boolValue];
     }
 
     NSMutableArray *products = [NSMutableArray array];
@@ -606,7 +606,7 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
     event.startTime = json[@"startTime"];
     event.type = [json[@"type"] intValue];
     if (json[@"shouldUploadEvent"] != nil) {
-        event.shouldUploadEvent = [json[@"shouldUploadEvent"] boolValue]
+        event.shouldUploadEvent = [json[@"shouldUploadEvent"] boolValue];
     }
 
     NSDictionary *jsonFlags = json[@"customFlags"];


### PR DESCRIPTION
Minor syntax errors:

<img width="1254" alt="Screen Shot 2021-09-21 at 10 09 22 AM" src="https://user-images.githubusercontent.com/19657993/134188439-df791fed-19c3-40ea-9374-21cbd4cd4626.png">
<img width="1265" alt="Screen Shot 2021-09-21 at 10 09 08 AM" src="https://user-images.githubusercontent.com/19657993/134188442-b8294726-665f-426e-beaf-7fd457671f84.png">


