### PR TITLE
fix: Remove deprecated jcenter references

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,7 @@ android {
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
@@ -33,7 +33,7 @@ buildscript {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     google()
 }
 

--- a/sample/android/build.gradle
+++ b/sample/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
@@ -14,7 +14,7 @@ buildscript {
 allprojects {
     repositories {
         mavenLocal()
-        jcenter()
+        mavenCentral()
         google()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm


### PR DESCRIPTION
## Summary
remove references to deprecated jcenter repository

## Testing Plan
Current tests are basically useless, but this same commit is included in the branch that adds effective tests. Passing run is [here](https://github.com/mParticle/react-native-mparticle/actions/runs/1262494776)

## Master Issue
Closes https://go.mparticle.com/work/72218
