### PR TITLE
Fix: Remove Extra ProductActionType Check

### DIFF
--- a/ios/RNMParticle/RNMParticle.m
+++ b/ios/RNMParticle/RNMParticle.m
@@ -413,7 +413,6 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
     commerceEvent.productListSource = json[@"productActionListSource"];
     commerceEvent.screenName = json[@"screenName"];
     commerceEvent.transactionAttributes = [RCTConvert MPTransactionAttributes:json[@"transactionAttributes"]];
-    commerceEvent.action = [RCTConvert MPCommerceEventAction:json[@"productActionType"]];
     commerceEvent.checkoutStep = [json[@"checkoutStep"] intValue];
     commerceEvent.nonInteractive = [json[@"nonInteractive"] boolValue];
     if (json[@"shouldUploadEvent"] != nil) {


### PR DESCRIPTION
## Summary
Developers are trying to implement a Promotion and Impression eCommerce event tracking in mP React Native and got the following warning, "Invalid commerce event action".

## Testing Plan
Testing through a sample React Native App

## Master Issue
Closes https://go.mparticle.com/work/77049
