### PR TITLE
Added Android mapping for Commerce Events (currency, checkoutStep, ch…

### DIFF
--- a/android/src/main/java/com/mparticle/react/MParticleModule.java
+++ b/android/src/main/java/com/mparticle/react/MParticleModule.java
@@ -598,6 +598,16 @@ public class MParticleModule extends ReactContextBaseJavaModule {
         if (map.hasKey("customAttributes")) {
             builder.customAttributes(ConvertStringMap(map.getMap("customAttributes")));
         }
+        if (map.hasKey("currency")) {
+            builder.currency(map.getString("currency"));
+        }
+        if (map.hasKey("checkoutStep")) {
+            builder.checkoutStep(map.getInt("checkoutStep"));
+        }
+        if (map.hasKey("checkoutOptions")) {
+            builder.checkoutOptions(map.getString("checkoutOptions"));
+        }
+
 
         return builder.build();
     }


### PR DESCRIPTION
…eckoutOptions)

## Summary
KFC reported no mapping of currency and checkout step in their Android React Native app. It worked fine in iOS. Upon inspection, there was no mapping of these functions, as well as checkoutOptions, nonInteractive, and screenName. I was able to get currency, checkout step, and checkout options working fine.

## Testing Plan
Made local changes to the react-native-mparticle module and passed events through, both before and after the change. Events successfully passed through with the changes and code built with no errors.
