### PR TITLE
fix to Android's getUserAttributes

### DIFF
--- a/android/src/main/java/com/mparticle/react/MParticleModule.java
+++ b/android/src/main/java/com/mparticle/react/MParticleModule.java
@@ -13,6 +13,8 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableNativeArray;
 import com.mparticle.AttributionResult;
 import com.mparticle.MParticle;
 import com.mparticle.MPEvent;
@@ -121,7 +123,19 @@ public class MParticleModule extends ReactContextBaseJavaModule {
             selectedUser.getUserAttributes(new UserAttributeListener() {
                 @Override
                 public void onUserAttributesReceived(Map<String, String> userAttributes, Map<String, List<String>> userAttributeLists, Long mpid) {
-                    completion.invoke(null, userAttributes);
+                    WritableMap resultMap = new WritableNativeMap();
+                    for (Map.Entry<String, String> entry : userAttributes.entrySet()) {
+                        resultMap.putString(entry.getKey(), entry.getValue());
+                    }
+                    for (Map.Entry<String, List<String>> entry : userAttributeLists.entrySet()) {
+                        WritableArray resultArray = new WritableNativeArray();
+                        List<String> valueList = entry.getValue();
+                        for (String arrayVal : valueList) {
+                            resultArray.pushString(arrayVal);
+                        }
+                        resultMap.putArray(entry.getKey(), resultArray);
+                    }
+                    completion.invoke(null, resultMap);
                 }
             });
         } else {


### PR DESCRIPTION
## Summary
The Burger King team reported that our React Native SDK crashes their Android app when using the function getUserAttributes. After further investigation I was able to reproduce and it seemed the reason is that we were passing an immutable Java map to the success callback when we needed to actually pass either a readable or writable maps. Also, the older implementation even missed logic to handle user attribute lists which is now also included.

## Testing Plan
Tested the fix on 4 scenarios locally and all worked as expected:
    - In case there where no user attributes in which the an empty map is returned.
    - In case there were only user attributes and not attributes lists and worked as expected.
    - In case there were only user attribute lists and worked as expected.
    - In case there were user attributes and attribute lists and works as expected.

## Master Issue
Closes https://go.mparticle.com/work/REPLACEME
