### PR TITLE
upper-bounded the android sdk version to 5.38.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     //
     // (See https://github.com/mparticle/mparticle-android-sdk for the latest version)
     //
-    compileOnly 'com.mparticle:android-core:[5.9.3, )'
+    compileOnly 'com.mparticle:android-core:[5.9.3, 5.38.2]'
 
     //
     // And, if you want to include kits, you can do so as follows:


### PR DESCRIPTION
## Summary
Fixes #67 

## Testing Plan
Given that this is merely limiting the SDK version to a version that has been out and working, this should not change functionality to require testing.

## Master Issue
N/A