### PR TITLE
parse string values transaction attributes to numbers

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -346,17 +346,17 @@ class TransactionAttributes {
   }
 
   setRevenue (revenue) {
-    this.revenue = revenue
+    this.revenue = typeof revenue === 'string' ? parseFloat(revenue) : revenue
     return this
   }
 
   setShipping (shipping) {
-    this.shipping = shipping
+    this.shipping = typeof shipping === 'string' ? parseFloat(shipping) : shipping
     return this
   }
 
   setTax (tax) {
-    this.tax = tax
+    this.tax = typeof tax === 'string' ? parseFloat(tax) : tax
     return this
   }
 


### PR DESCRIPTION
## Summary
This PR closes this feature request Jira ticket (https://mparticle-eng.atlassian.net/browse/PRODRDMP-5034). The KFC SA team reported that our React Native SDK show values 0 for Tax and Shipping. It was confirmed that later that they were using string values whereas the expected value was expected to be numeric. Our web SDK does parse string values to numeric values when testing and they expected the same behavior for the React Native SDK. The code change here does parse string values into numeric and also works in the case the values are already passed in as numeric values

## Testing Plan
Tested locally on both iOS and Android with both cases when a numeric value is entered and when a string value is entered
