### PR TITLE
fix: correct quantity value conversion

### DIFF
--- a/ios/RNMParticle/RNMParticle.m
+++ b/ios/RNMParticle/RNMParticle.m
@@ -487,7 +487,7 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
     product.sku = json[@"sku"];
     product.variant = json[@"variant"];
     product.position = [json[@"position"] intValue];
-    product.quantity = json[@"quantity"];
+    product.quantity = @([json[@"quantity"] intValue]);
     NSDictionary *jsonAttributes = json[@"customAttributes"];
     for (NSString *key in jsonAttributes) {
         NSString *value = jsonAttributes[key];


### PR DESCRIPTION
## Summary
Quantity is expected to be a NSNumber for the core SDK and then an int for google analytics but the the translation layer in react was causing a malformed object. This change explicitly casts the value correctly.

## Testing Plan
Tested in example app for ios with Google Analytics (but not GA4) set up

## Master Issue
Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-4535
