### PR TITLE
feat: Allow uploadInterval to be set manually

### DIFF
--- a/android/src/main/java/com/mparticle/react/MParticleModule.java
+++ b/android/src/main/java/com/mparticle/react/MParticleModule.java
@@ -69,6 +69,11 @@ public class MParticleModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void setUploadInterval(int uploadInterval) {
+        MParticle.getInstance().setUpdateInterval(uploadInterval);
+    }
+
+    @ReactMethod
     public void logEvent(final String name, int type, final ReadableMap attributesMap) {
         Map<String, String> attributes = ConvertStringMap(attributesMap);
         MParticle.EventType eventType = ConvertEventType(type);

--- a/ios/RNMParticle/RNMParticle.m
+++ b/ios/RNMParticle/RNMParticle.m
@@ -24,6 +24,11 @@ RCT_EXPORT_METHOD(upload)
     [[MParticle sharedInstance] upload];
 }
 
+RCT_EXPORT_METHOD(setUploadInterval:(NSInteger)uploadInterval)
+{
+    [[MParticle sharedInstance] setUploadInterval:uploadInterval];
+}
+
 RCT_EXPORT_METHOD(logEvent:(NSString *)eventName type:(NSInteger)type attributes:(NSDictionary *)attributes)
 {
     [[MParticle sharedInstance] logEvent:eventName eventType:type eventInfo:attributes];

--- a/js/index.js
+++ b/js/index.js
@@ -88,6 +88,10 @@ const upload = () => {
   NativeModules.MParticle.upload()
 }
 
+const setUploadInterval = (uploadInterval) => {
+  NativeModules.MParticle.setUploadInterval(uploadInterval)
+}
+
 const logEvent = (eventName, type = EventType.Other, attributes = null) => {
   NativeModules.MParticle.logEvent(eventName, type, attributes)
 }
@@ -664,8 +668,9 @@ const MParticle = {
   GDPRConsent,
   CCPAConsent,
 
-  upload,
-  logEvent,             // Methods
+  upload,             // Methods
+  setUploadInterval,
+  logEvent,
   logMPEvent,
   logCommerceEvent,
   logScreenEvent,


### PR DESCRIPTION
## Summary
Allow the newly updated uploadInterval to be settable by the React Native SDK

## Testing Plan
Tested in my own sample app using latest Android and pointing to the corresponding fix branch on the iOS SDK (this needs released before we release the new React Native SDK)

## Master Issue
Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-4949
