### PR TITLE
docs: Update Readme for static frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,33 @@ $ react-native link
 
 ## <a name="iOS"></a>iOS
 
-1. **Copy your mParticle key and secret** from [your app's dashboard][1].
+1. **Install the SDK** using CocoaPods:
 
-[1]: https://app.mparticle.com/setup/inputs/apps
+Add the following 2 lines to you Podfile in the ios folder
+```bash
+  pod 'mParticle-Apple-SDK'
 
-2. **Install the SDK** using CocoaPods:
+  use_frameworks! :linkage => :static
 
+    # :flipper_configuration => flipper_config,
+```
+Disable the last line of code as shown bellow in the Podfile as it instructs for when using frameworks. 
+```bash
+    # Enables Flipper.
+    #
+    # Note that if you have use_frameworks! enabled, Flipper will not work and
+    # you should disable the next line.
+    # :flipper_configuration => flipper_config,
+```
+Install the sdk with CocoaPods.
 ```bash
 $ # Update your Podfile to depend on 'mParticle-Apple-SDK' version 7.2.0 or later
-$ pod install
+$ pod install  --repo-update
 ```
+
+2. **Copy your mParticle key and secret** from [your app's dashboard][1].
+
+[1]: https://app.mparticle.com/setup/inputs/apps
 
 The mParticle SDK is initialized by calling the `startWithOptions` method within the `application:didFinishLaunchingWithOptions:` delegate call.
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ Add the following 2 lines to you Podfile in the ios folder
   pod 'mParticle-Apple-SDK'
 
   use_frameworks! :linkage => :static
-
-    # :flipper_configuration => flipper_config,
 ```
 Disable the last line of code as shown bellow in the Podfile as it instructs for when using frameworks. 
 ```bash


### PR DESCRIPTION
## Summary
As discussed [here](https://github.com/reactwg/react-native-new-architecture/discussions/115) and [here](https://github.com/invertase/react-native-firebase/discussions/6446)  the use of static framework requires extra setup in your Podfile. This PR updates the docs to note these additional requirements.

## Testing Plan
Tested locally

## Master Issue
Closes https://go.mparticle.com/work/REPLACEME
