### PR TITLE
docs: Remove npm link from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,10 @@ React Native allows developers to use a single code base to deploy features to m
 
 # Installation
 
-1. **Download and install the mParticle React Native library** from npm:
+**Download and install the mParticle React Native library** from npm:
 
 ```bash
 $ npm install react-native-mparticle --save
-```
-
-2. **Install the native dependencies**.
-
-```bash
-$ npm link react-native-mparticle
 ```
 
 ## <a name="iOS"></a>iOS


### PR DESCRIPTION
## Summary
The npm link step is unnecessary and only for local development of npm packages.  Now that this will be released, it is not needed.

## Testing Plan
Built an iOS and Android app, and logged setLocation successfully.

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-6226