### PR TITLE
feat(identity): add device application stamp read capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,16 @@ MParticle.Identity.modify(request, (error, userId) => {
 });
 ```
 
+```js
+MParticle.Identity.getCurrentDeviceApplicationStamp((error, deviceApplicationStamp) => {
+    if (error) {
+        console.debug(error); //error is an MParticleError
+    } else {
+        console.debug(deviceApplicationStamp);
+    }
+});
+```
+
 ## Attribution
 ```
 var attributions = MParticle.getAttributions();

--- a/android/src/main/java/com/mparticle/react/MParticleModule.java
+++ b/android/src/main/java/com/mparticle/react/MParticleModule.java
@@ -295,6 +295,12 @@ public class MParticleModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void getCurrentDeviceApplicationStampWithCompletion(Callback completion) {
+        MParticleUser deviceApplication = MParticle.getInstance().Identity().getDeviceApplicationStamp();        
+        completion.invoke(null, deviceApplication);
+    }
+
+    @ReactMethod
     public void aliasUsers(final ReadableMap readableMap, final Callback completion) {
         IdentityApi identityApi = MParticle.getInstance().Identity();
         ReadableMapKeySetIterator iterator = readableMap.keySetIterator();

--- a/ios/RNMParticle/RNMParticle.m
+++ b/ios/RNMParticle/RNMParticle.m
@@ -345,6 +345,11 @@ RCT_EXPORT_METHOD(getCurrentUserWithCompletion:(RCTResponseSenderBlock)completio
     completion(@[[NSNull null], [[[MParticle sharedInstance] identity] currentUser].userId.stringValue]);
 }
 
+RCT_EXPORT_METHOD(getCurrentDeviceApplicationStampWithCompletion:(RCTResponseSenderBlock)completion)
+{
+    completion(@[[NSNull null], [[[MParticle sharedInstance] identity] deviceApplicationStamp]]);
+}
+
 RCT_EXPORT_METHOD(getUserIdentities:(NSString *)userId completion:(RCTResponseSenderBlock)completion)
 {
     MParticleUser *selectedUser = [[MParticleUser alloc] init];

--- a/js/index.js
+++ b/js/index.js
@@ -305,6 +305,16 @@ class Identity {
     NativeModules.MParticle.aliasUsers(AliasRequest, completion)
   }
 
+  static getCurrentDeviceApplicationStamp (completion) {
+    NativeModules.MParticle.getCurrentDeviceApplicationStampWithCompletion((error, deviceApplicationStamp) => {
+      if (error) {
+        var parsedError = new MParticleError(error);
+        completion(parsedError, undefined);
+        return;
+      }
+      completion(undefined, deviceApplicationStamp);
+    });
+  }
 }
 
 // ******** Commerce ********


### PR DESCRIPTION
## Summary
- Add a `getCurrentDeviceApplicationStamp` method to the Identity Class.
- - Android Identity method -> https://github.com/mParticle/mparticle-android-sdk/blob/main/android-core/src/main/java/com/mparticle/identity/IdentityApi.java#L122
- - iOS Identity method -> https://github.com/mParticle/mparticle-apple-sdk/blob/main/mParticle-Apple-SDK/Identity/MPIdentityApi.m#L361

## Testing Plan
- With local changes, publish the react-native-mparticle module using [yalc](https://www.npmjs.com/package/yalc/v/1.0.0-pre.23) or through [npm-link](https://docs.npmjs.com/cli/v9/commands/npm-link)
- Install the local package with the according method on your Android or iOS device
- Call from the bundle:
```js
MParticle.Identity.getCurrentDeviceApplicationStamp((error, deviceApplicationStamp) => {
    if (error) {
        console.error(error);
    } else {
        console.log(deviceApplicationStamp);
    }
});
```
and you should get a resulting GUID value:
![image](https://github.com/mParticle/react-native-mparticle/assets/7375014/985c9155-ce14-4d03-b73f-4206eaf8da40)

## Master Issue
No related Issue.
