### PR TITLE
fix: Fix setVariant on Product

### DIFF
--- a/android/src/main/java/com/mparticle/react/MParticleModule.java
+++ b/android/src/main/java/com/mparticle/react/MParticleModule.java
@@ -684,6 +684,11 @@ public class MParticleModule extends ReactContextBaseJavaModule {
             builder.quantity(quantity);
         }
 
+        if (map.hasKey("variant")) {
+            String variant = map.getString("variant");
+            builder.variant(variant);
+        }
+
         return builder.build();
     }
 


### PR DESCRIPTION
## Summary
When you are using our android react native sdk ("react-native-mparticle": "^2.7.11") the method product.setVariant() is not forwarding the right value to mParticle. We can see in the “Live Stream” the batch containing the null value for this field, despite we have tried to set it to an string/numeric value. This was confirmed to work iOS so the problem laid entirely in the android layer, specifically were we convert the MPProduct json object to the proper android class MPProduct.

## Testing Plan
Tested in sample App

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-6497
