### PR TITLE
Added isLoggedIn property to get current user object fetched from getCurrentUser method

### DIFF
--- a/android/src/main/java/com/mparticle/react/MParticleModule.java
+++ b/android/src/main/java/com/mparticle/react/MParticleModule.java
@@ -287,9 +287,10 @@ public class MParticleModule extends ReactContextBaseJavaModule {
         MParticleUser currentUser = MParticle.getInstance().Identity().getCurrentUser();
         if (currentUser != null) {
             String userID = Long.toString(currentUser.getId());
-            completion.invoke(null, userID);
+            boolean isLoggedIn = currentUser.isLoggedIn;
+            completion.invoke(null, userID, isLoggedIn);
         } else {
-            completion.invoke(null, null);
+            completion.invoke(null, null, false);
         }
 
     }

--- a/ios/RNMParticle/RNMParticle.m
+++ b/ios/RNMParticle/RNMParticle.m
@@ -349,7 +349,8 @@ RCT_EXPORT_METHOD(aliasUsers:(MPAliasRequest *) aliasRequest completion:(RCTResp
 
 RCT_EXPORT_METHOD(getCurrentUserWithCompletion:(RCTResponseSenderBlock)completion)
 {
-    completion(@[[NSNull null], [[[MParticle sharedInstance] identity] currentUser].userId.stringValue]);
+    MParticleUser *currentUser = [[MParticle sharedInstance] identity].currentUser;
+    completion(@[[NSNull null], currentUser.userId.stringValue, @(currentUser.isLoggedIn)]);
 }
 
 RCT_EXPORT_METHOD(getUserIdentities:(NSString *)userId completion:(RCTResponseSenderBlock)completion)

--- a/js/index.js
+++ b/js/index.js
@@ -164,8 +164,9 @@ const setLocation = (latitude, longitude) => {
 
 // ******** Identity ********
 class User {
-  constructor (userId) {
-    this.userId = userId
+  constructor (userId, isLoggedIn = false) {
+    this.userId = userId;
+    this.isLoggedIn = isLoggedIn;
   }
 
   getMpid () {
@@ -248,13 +249,15 @@ class IdentityRequest {
 class Identity {
 
   static getCurrentUser (completion) {
-    NativeModules.MParticle.getCurrentUserWithCompletion((error, userId) => {
-      if (error) {
-        console.log(error.stack)
+    NativeModules.MParticle.getCurrentUserWithCompletion(
+      (error, userId, isLoggedIn) => {
+        if (error) {
+          console.log(error.stack);
+        }
+        var currentUser = new User(userId, isLoggedIn);
+        completion(currentUser);
       }
-      var currentUser = new User(userId)
-      completion(currentUser)
-    })
+    );
   }
 
   static identify (IdentityRequest, completion) {

--- a/js/index.js
+++ b/js/index.js
@@ -164,9 +164,8 @@ const setLocation = (latitude, longitude) => {
 
 // ******** Identity ********
 class User {
-  constructor (userId, isLoggedIn = false) {
-    this.userId = userId;
-    this.isLoggedIn = isLoggedIn;
+  constructor (userId) {
+    this.userId = userId
   }
 
   getMpid () {
@@ -249,15 +248,15 @@ class IdentityRequest {
 class Identity {
 
   static getCurrentUser (completion) {
-    NativeModules.MParticle.getCurrentUserWithCompletion(
-      (error, userId, isLoggedIn) => {
-        if (error) {
-          console.log(error.stack);
-        }
-        var currentUser = new User(userId, isLoggedIn);
-        completion(currentUser);
+    NativeModules.MParticle.getCurrentUserWithCompletion((error, userId, isLoggedIn) => {
+      if (error) {
+        console.log(error.stack);
       }
-    );
+      var currentUser = new User(userId);
+      currentUser.isLoggedIn = isLoggedIn || false;
+      completion(currentUser);
+    }
+  );
   }
 
   static identify (IdentityRequest, completion) {


### PR DESCRIPTION
## Summary
Currently, the getCurrentUser method returns an object with only the userId property, but it would be useful to also include the isLoggedIn property to determine the login status of the current user.

**Current behavior:**
`getCurrentUser()` only returns an object with the userId property:

`{ userId: "1" }`

**Expected behavior:**
`getCurrentUser()` should return an object with both `userId` and `isLoggedIn` properties, where isLoggedIn is a boolean indicating whether the user is logged in or not:

`{ userId: "1", isLoggedIn: true }`

**Changes Done:**
Modified the getCurrentUser method to return the isLoggedIn property along with userId. This will provide more comprehensive information about the current user and their session status.

**Additional context:**
This update would allow users or developers to directly access the login status of the current user without needing to perform a separate check.

## Testing Plan
This can be tested by calling the `getCurrentUser` Method and verifying the current user response object,

## Master Issue
Closes https://github.com/mParticle/react-native-mparticle/issues/213