### PR TITLE
fix: update architecture checks to use isFabricEnabled in RoktLayoutView iOS

### DIFF
--- a/js/rokt/rokt-layout-view.ios.tsx
+++ b/js/rokt/rokt-layout-view.ios.tsx
@@ -9,7 +9,7 @@ import {
   UIManager,
 } from 'react-native';
 import React, { Component } from 'react';
-import { isNewArchitecture } from '../utils/architecture';
+import { isFabricEnabled } from '../utils/architecture';
 import RoktLayoutNativeComponent from '../codegenSpecs/rokt/RoktLayoutNativeComponent';
 
 const RoktEventManager = NativeModules.RoktEventManager as NativeModule;
@@ -52,7 +52,7 @@ interface RoktNativeLayoutProps extends ViewProps {
 
 // Use the appropriate component based on architecture
 const LayoutNativeComponent = (
-  isNewArchitecture
+  isFabricEnabled
     ? RoktLayoutNativeComponent
     : requireNativeComponent<RoktNativeLayoutProps>('RoktLegacyLayout')
 ) as any;

--- a/js/rokt/rokt-layout-view.ios.tsx
+++ b/js/rokt/rokt-layout-view.ios.tsx
@@ -3,10 +3,8 @@ import {
   StyleSheet,
   NativeEventEmitter,
   NativeModules,
-  HostComponent,
   ViewProps,
   NativeModule,
-  UIManager,
 } from 'react-native';
 import React, { Component } from 'react';
 import { isFabricEnabled } from '../utils/architecture';

--- a/js/utils/architecture.ts
+++ b/js/utils/architecture.ts
@@ -2,9 +2,12 @@ import { NativeModules, TurboModuleRegistry, TurboModule } from 'react-native';
 
 declare const global: {
   __turboModuleProxy: unknown;
+  nativeFabricUIManager: unknown;
 };
 
 export const isNewArchitecture = global.__turboModuleProxy != null;
+
+export const isFabricEnabled = global.nativeFabricUIManager != null;
 
 /**
  * Gets the native module for both old and new architectures


### PR DESCRIPTION
## Summary
Load the legacy native view if Fabric components are not enabled.


## Testing Plan
Tested with RN version `0.76.9` and `0.79.4`

## Master Issue
Closes https://go.mparticle.com/work/REPLACEME
