### PR TITLE
fix: add iOS configuration for RoktNativeLayout in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "jsSrcsDir": "js/codegenSpecs",
     "android": {
       "javaPackageName": "com.mparticle.react"
+    },
+    "ios": {
+      "RoktNativeLayout": "RoktNativeLayoutComponentView"
     }
   }
 }


### PR DESCRIPTION
## Summary
In new version of RN view class name was not detected automatically. Add the mapping configuration in codegen config

## Testing Plan
{explain how this has been tested, and what additional testing should be done}

## Master Issue
Closes https://go.mparticle.com/work/REPLACEME
