### PR TITLE
feat: add purchaseFinalized method to Rokt module for both iOS and Android

### DIFF
--- a/android/src/newarch/java/com/mparticle/react/rokt/MPRoktModule.kt
+++ b/android/src/newarch/java/com/mparticle/react/rokt/MPRoktModule.kt
@@ -55,6 +55,15 @@ class MPRoktModule(
         )
     }
 
+    @ReactMethod
+    override fun purchaseFinalized(
+        placementId: String,
+        catalogItemId: String,
+        success: Boolean,
+    ) {
+        impl.purchaseFinalized(placementId, catalogItemId, success)
+    }
+
 
     /**
      * Process placeholders from ReadableMap to a map of Widgets for use with Rokt.

--- a/android/src/oldarch/java/com/mparticle/react/NativeMPRoktSpec.kt
+++ b/android/src/oldarch/java/com/mparticle/react/NativeMPRoktSpec.kt
@@ -20,4 +20,10 @@ abstract class NativeMPRoktSpec(
         roktConfig: ReadableMap?,
         fontFilesMap: ReadableMap?,
     )
+
+    abstract fun purchaseFinalized(
+        placementId: String,
+        catalogItemId: String,
+        success: Boolean,
+    )
 }

--- a/android/src/oldarch/java/com/mparticle/react/rokt/MPRoktModule.kt
+++ b/android/src/oldarch/java/com/mparticle/react/rokt/MPRoktModule.kt
@@ -53,6 +53,15 @@ class MPRoktModule(
         }
     }
 
+    @ReactMethod
+    override fun purchaseFinalized(
+        placementId: String,
+        catalogItemId: String,
+        success: Boolean,
+    ) {
+        impl.purchaseFinalized(placementId, catalogItemId, success)
+    }
+
     private fun safeUnwrapPlaceholders(
         placeholders: ReadableMap?,
         nativeViewHierarchyManager: NativeViewHierarchyManager,

--- a/ios/RNMParticle/RNMPRokt.mm
+++ b/ios/RNMParticle/RNMPRokt.mm
@@ -129,6 +129,13 @@ RCT_EXPORT_METHOD(selectPlacements:(NSString *) identifer attributes:(NSDictiona
     }];
 }
 
+RCT_EXPORT_METHOD(purchaseFinalized : (NSString *)placementId catalogItemId : (
+    NSString *)catalogItemId success : (BOOL)success) {
+    [[[MParticle sharedInstance] rokt] purchaseFinalized:placementId
+                                           catalogItemId:catalogItemId
+                                                 success:success];
+}
+
 - (NSMutableDictionary*)convertToMutableDictionaryOfStrings:(NSDictionary*)attributes
 {
     NSMutableDictionary *finalAttributes = [attributes mutableCopy];

--- a/js/codegenSpecs/rokt/NativeMPRokt.ts
+++ b/js/codegenSpecs/rokt/NativeMPRokt.ts
@@ -21,6 +21,12 @@ export interface Spec extends TurboModule {
     roktConfig?: RoktConfigType,
     fontFilesMap?: { [key: string]: string }
   ): void;
+
+  purchaseFinalized(
+    placementId: string,
+    catalogItemId: string,
+    success: boolean
+  ): void;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('RNMPRokt');

--- a/js/rokt/rokt.ts
+++ b/js/rokt/rokt.ts
@@ -31,6 +31,14 @@ export abstract class Rokt {
     );
   }
 
+  static async purchaseFinalized(
+    placementId: string,
+    catalogItemId: string,
+    success: boolean
+  ): Promise<void> {
+    MPRokt.purchaseFinalized(placementId, catalogItemId, success);
+  }
+
   static createRoktConfig(colorMode?: ColorMode, cacheConfig?: CacheConfig) {
     return new RoktConfig(colorMode ?? 'system', cacheConfig);
   }


### PR DESCRIPTION
## Summary

- Implemented purchaseFinalized method in MPRoktModule for Android.
- Added corresponding method in RNMPRokt for iOS.
- Updated TypeScript definitions to include purchaseFinalized in the Rokt interface.

## Testing Plan

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-7456
