### PR TITLE
fix: use eventName in logEvent for Android

### DIFF
--- a/android/src/main/java/com/mparticle/react/MParticleModule.kt
+++ b/android/src/main/java/com/mparticle/react/MParticleModule.kt
@@ -73,7 +73,7 @@ class MParticleModule(
 
         val event =
             MPEvent
-                .Builder(name, eventType)
+                .Builder(eventName, eventType)
                 .customAttributes(attributes)
                 .build()
         MParticle.getInstance()?.logEvent(event)


### PR DESCRIPTION
Events logged with a custom event name using:
```js
MParticle.logEvent('Test event', MParticle.EventType.Other, { 'Test key': 'Test value' })
```
come through the to mParticle dashboard with an event name of `RNMParticle`:

<img width="353" height="72" alt="Screenshot 2025-09-01 at 14 12 37" src="https://github.com/user-attachments/assets/3a4b78dd-4cb6-45ed-bfbf-30fee297170a" />

I believe this was introduced in https://github.com/mParticle/react-native-mparticle/commit/919c83c1ff397d0ed0a622272ad6f3c2df857b2e - the parameter name was changed from `name` to `eventName` between the [java](https://github.com/mParticle/react-native-mparticle/blob/a09018ce0eb1d2b9c9404549d2f3b7eb8fbc2e14/android/src/main/java/com/mparticle/react/MParticleModule.java#L87) and [kotlin](https://github.com/mParticle/react-native-mparticle/blob/919c83c1ff397d0ed0a622272ad6f3c2df857b2e/android/src/main/java/com/mparticle/react/MParticleModule.kt#L66) files, but `name` is passed to `MPEvent.Builder` in both cases, so the kotlin version is picking up the module name `RNMParticle`.

This PR just changes the call to `MPEvent.Builder` to pass in `eventName` instead of `name`.