### PR TITLE
fix: remove userIdentities key expectation in native iOS logic

### DIFF
--- a/ios/RNMParticle/RNMParticle.mm
+++ b/ios/RNMParticle/RNMParticle.mm
@@ -651,23 +651,25 @@ RCT_EXPORT_METHOD(setCCPAConsentState:(MPCCPAConsent *)consent)
     }
     MPIdentityApiRequest *request = [MPIdentityApiRequest requestWithEmptyUser];
 
-    if (dict[@"userIdentities"] && dict[@"userIdentities"] != [NSNull null]) {
-        NSDictionary *identities = dict[@"userIdentities"];
-        for (NSString *key in identities) {
-            MPIdentity identityType = (MPIdentity)[key integerValue];
-            NSString *value = identities[key];
-            [request setIdentity:value identityType:identityType];
+    for (NSString *key in dict) {
+        id value = dict[key];
+        if (value == [NSNull null]) {
+            continue;
+        }
+        
+        if ([key isEqualToString:@"email"]) {
+            request.email = (NSString *)value;
+        } else if ([key isEqualToString:@"customerId"]) {
+            request.customerId = (NSString *)value;
+        } else {
+            NSCharacterSet *numericSet = [NSCharacterSet decimalDigitCharacterSet];
+            NSCharacterSet *keyCharacterSet = [NSCharacterSet characterSetWithCharactersInString:key];
+            if ([numericSet isSupersetOfSet:keyCharacterSet]) {
+                MPIdentity identityType = (MPIdentity)[key integerValue];
+                [request setIdentity:(NSString *)value identityType:identityType];
+            }
         }
     }
-
-    if (dict[@"customerId"] && dict[@"customerId"] != [NSNull null]) {
-        request.customerId = dict[@"customerId"];
-    }
-
-    if (dict[@"email"] && dict[@"email"] != [NSNull null]) {
-        request.email = dict[@"email"];
-    }
-
     return request;
 }
 
@@ -1091,21 +1093,24 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
     NSDictionary *dict = json;
     MPIdentityApiRequest *request = [MPIdentityApiRequest requestWithEmptyUser];
 
-    if (dict[@"userIdentities"] && dict[@"userIdentities"] != [NSNull null]) {
-        NSDictionary *identities = dict[@"userIdentities"];
-        for (NSString *key in identities) {
-            MPIdentity identityType = (MPIdentity)[key integerValue];
-            NSString *value = identities[key];
-            [request setIdentity:value identityType:identityType];
+    for (NSString *key in dict) {
+        id value = dict[key];
+        if (value == [NSNull null]) {
+            continue;
         }
-    }
-
-    if (dict[@"customerId"] && dict[@"customerId"] != [NSNull null]) {
-        request.customerId = dict[@"customerId"];
-    }
-
-    if (dict[@"email"] && dict[@"email"] != [NSNull null]) {
-        request.email = dict[@"email"];
+        
+        if ([key isEqualToString:@"email"]) {
+            request.email = (NSString *)value;
+        } else if ([key isEqualToString:@"customerId"]) {
+            request.customerId = (NSString *)value;
+        } else {
+            NSCharacterSet *numericSet = [NSCharacterSet decimalDigitCharacterSet];
+            NSCharacterSet *keyCharacterSet = [NSCharacterSet characterSetWithCharactersInString:key];
+            if ([numericSet isSupersetOfSet:keyCharacterSet]) {
+                MPIdentity identityType = (MPIdentity)[key integerValue];
+                [request setIdentity:(NSString *)value identityType:identityType];
+            }
+        }
     }
 
     return request;


### PR DESCRIPTION
## Summary
Setting identities through the mParticle module running on iOS resulted in those identities not being passed through to the mParticle dashboard. This is down to a mismatch between the codegen spec and the iOS implementation:

https://github.com/mParticle/react-native-mparticle/blob/98019343c491251b94ddb3c1f47c3e650c7de62d/js/codegenSpecs/NativeMParticle.ts#L106

https://github.com/mParticle/react-native-mparticle/blob/98019343c491251b94ddb3c1f47c3e650c7de62d/ios/RNMParticle/RNMParticle.mm#L648-L672

and

https://github.com/mParticle/react-native-mparticle/blob/98019343c491251b94ddb3c1f47c3e650c7de62d/ios/RNMParticle/RNMParticle.mm#L1090-L1112

This PR removes the expectation that there will be a `userIdentities` dict in the identity request in the native iOS code and aligns its implementation with the interface described by the codegen spec
