### PR TITLE
chore: update mParticle android sdk to version 5.76.1 in sample app

### DIFF
--- a/sample/android/app/build.gradle
+++ b/sample/android/app/build.gradle
@@ -110,8 +110,8 @@ android {
 dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
-    implementation("com.mparticle:android-core:5.71.0")
-    implementation("com.mparticle:android-rokt-kit:5.71.0")
+    implementation("com.mparticle:android-core:5.76.1")
+    implementation("com.mparticle:android-rokt-kit:5.76.1")
 
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")


### PR DESCRIPTION
## Summary
Update native Android SDK version to 5.76.1

## Testing Plan
Tested locally

## Master Issue
Closes https://go.mparticle.com/work/REPLACEME
