### PR TITLE
fix(ios): remove SPM duplicate for mParticle-Apple-SDK

### DIFF
--- a/react-native-mparticle.podspec
+++ b/react-native-mparticle.podspec
@@ -25,16 +25,5 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
 
-  # Primary: CocoaPods dependency (still works when SPM is not used)
   s.dependency 'mParticle-Apple-SDK', '~> 8.0'
-
-  # SPM bridge: registers mParticle-Apple-SDK as an SPM dependency alongside CocoaPods (RN 0.75+).
-  # See: https://github.com/facebook/react-native/pull/44627
-  if respond_to?(:spm_dependency, true)
-    spm_dependency(s,
-      url: 'https://github.com/mParticle/mparticle-apple-sdk.git',
-      requirement: { kind: 'upToNextMajorVersion', minimumVersion: '8.0.0' },
-      products: ['mParticle-Apple-SDK']
-    )
-  end
 end


### PR DESCRIPTION
## Summary
Removes the `spm_dependency` block from `react-native-mparticle.podspec`. iOS continues to use the existing CocoaPods dependency on `mParticle-Apple-SDK`.

## Why
React Native’s SPM bridge pulled the same Apple SDK xcframework alongside CocoaPods, which led to duplicate `mParticle_Apple_SDK.xcframework-ios.signature` collection and Release archive failures (including EAS).

## Closes
Closes #308

Made with [Cursor](https://cursor.com)