### PR TITLE
ci: Add --allow-same-version to draft release workflow

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -41,7 +41,7 @@ jobs:
         run: echo "${{ steps.bump-version.outputs.new_version }}" > VERSION
 
       - name: Update package.json version
-        run: npm version "${{ steps.bump-version.outputs.new_version }}" --no-git-tag-version
+        run: npm version "${{ steps.bump-version.outputs.new_version }}" --no-git-tag-version --allow-same-version
 
       - name: Generate changelog from git history
         id: changelog


### PR DESCRIPTION
## Summary
Adds --allow-same-version flag to the npm version commands in draft-release-publish.yml
Fixes the workflow failure when version already matches the bumped version 
Ref: https://github.com/mParticle/react-native-mparticle/actions/runs/24521190654/job/71679099165#step:6:7

## Testing Plan
Re-run the publish-draft-release workflow with major bump type and confirm it passes

## Master Issue
Closes https://go.mparticle.com/work/REPLACEME
