### PR TITLE
fix: pin android-core upper bound to prevent 6.0.0-rc.1 pull (#710)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -118,7 +118,9 @@ dependencies {
     //
     // (See https://github.com/mparticle/mparticle-android-sdk for the latest version)
     //
-    api 'com.mparticle:android-core:[5.79.0, )'
+    // Bounded upper bound prevents resolving to 6.0.0-rc.1+ on Maven Central.
+    // 6.x removed deprecated symbols (e.g. UserAttributeListener); see #710.
+    api 'com.mparticle:android-core:[5.79.0, 6.0)'
 
     //
     // And, if you want to include kits, you can do so as follows:


### PR DESCRIPTION
## Summary

- Closes mParticle/mparticle-android-sdk#710
- Replace open-ended `[5.79.0, )` range with `[5.79.0, 6.0)` for the `com.mparticle:android-core` dependency in `android/build.gradle`.

## Why

`com.mparticle:android-core:6.0.0-rc.1` was published to Maven Central on 2026-05-22. The open-ended range resolves to the highest available version, which is now the RC. 6.x removed deprecated symbols including `com.mparticle.UserAttributeListener` (referenced by this module), so consumers who built successfully before 2026-05-22 are now broken with no change on their side:

```
error: cannot find symbol
import com.mparticle.UserAttributeListener;
                    ^
  symbol:   class UserAttributeListener
```

The bounded upper bound restores the previous behavior and gates 6.x adoption behind an explicit version bump in this module.

## Test plan

- [ ] `cd android && ./gradlew assembleRelease` succeeds (was failing with `cannot find symbol: UserAttributeListener`).
- [ ] Consumer repro from issue #710 builds again after upgrading to the version that contains this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)