### PR TITLE
fix: bound android kit upper version in expo config plugin

### DIFF
--- a/plugin/src/withMParticleAndroid.ts
+++ b/plugin/src/withMParticleAndroid.ts
@@ -364,9 +364,12 @@ const withMParticleAppBuildGradle: ConfigPlugin<MParticlePluginProps> = (
     }
 
     // Generate kit dependency lines
-    // Use + for version to auto-match core SDK version
+    // Bounded range matches the core SDK range in android/build.gradle so the
+    // kit and core stay paired on a 5.x line. An unbounded `+` would resolve
+    // to a pre-release (e.g. 6.0.0-rc.1) and transitively drag the core past
+    // the bridge's compiled-against API surface.
     const kitDependencies = props.androidKits
-      .map(kit => `    implementation "com.mparticle:${kit}:+"`)
+      .map(kit => `    implementation "com.mparticle:${kit}:[5.79.0, 6.0)"`)
       .join('\n');
 
     // Use mergeContents for idempotent injection


### PR DESCRIPTION
## Summary
- The expo config plugin emits `implementation "com.mparticle:${kit}:+"` for each entry in `androidKits`. The `:+` resolver pulls the newest available version on Maven Central — currently `6.0.0-rc.1`.
- That kit transitively requires `com.mparticle:android-core:6.0.0-rc.1`, which overrides the bridge's `api 'com.mparticle:android-core:[5.79.0, 6.0)'` range via Gradle's default conflict resolution (highest-required-version wins).
- The bridge AAR is compiled against 5.x core, but the app's runtime classpath ends up on 6.x core where several referenced classes no longer exist, producing `NoClassDefFoundError` at launch (e.g. `com/mparticle/rokt/RoktEmbeddedView`).

This change bounds the kit dependency to the same `[5.79.0, 6.0)` range used for the core SDK, so kit resolution stays inside the 5.x line that the bridge is built against.

## Test plan
- [ ] `expo prebuild` an app with `androidKits` configured and confirm `app/build.gradle` emits a bounded version range instead of `:+`.
- [ ] `./gradlew :app:dependencies --configuration debugRuntimeClasspath` resolves `android-core` and `android-rokt-kit` to a 5.x version.
- [ ] App launches without `NoClassDefFoundError` on classes from `com.mparticle.rokt`.
- [ ] Existing plugin unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)