### PR TITLE
feat: Java enum for MPCommerceEventActionType was base 1

### DIFF
--- a/ios/RNMParticle/RNMParticle.mm
+++ b/ios/RNMParticle/RNMParticle.mm
@@ -19,6 +19,12 @@
 - (void)setUserId:(NSNumber *)userId;
 @end
 
+// Forward declare so New Arch `logCommerceEvent` can use the same JS→native
+// product action mapping as `RCTConvert MPCommerceEvent:` (defined later in this file).
+@interface RCTConvert (MPCommerceEvent)
++ (MPCommerceEventAction)MPCommerceEventAction:(id)json;
+@end
+
 @implementation RNMParticle
 
 RCT_EXTERN void RCTRegisterModule(Class);
@@ -447,7 +453,7 @@ RCT_EXPORT_METHOD(getSession:(RCTResponseSenderBlock)completion)
     MPCommerceEvent *mpCommerceEvent = [[MPCommerceEvent alloc] init];
 
     if (commerceEvent.productActionType().has_value()) {
-        mpCommerceEvent.action = (MPCommerceEventAction)commerceEvent.productActionType().value();
+        mpCommerceEvent.action = [RCTConvert MPCommerceEventAction:@(commerceEvent.productActionType().value())];
     }
 
     if (commerceEvent.promotionActionType().has_value()) {
@@ -778,7 +784,7 @@ RCT_EXPORT_METHOD(setCCPAConsentState:(MPCCPAConsent *)consent)
     MPCommerceEvent *commerceEvent = [[MPCommerceEvent alloc] init];
 
     if (dict[@"productActionType"] && dict[@"productActionType"] != [NSNull null]) {
-        commerceEvent.action = (MPCommerceEventAction)[dict[@"productActionType"] integerValue];
+        commerceEvent.action = [RCTConvert MPCommerceEventAction:dict[@"productActionType"]];
     }
 
     if (dict[@"products"] && dict[@"products"] != [NSNull null]) {

--- a/ios/RNMParticle/RNMParticle.mm
+++ b/ios/RNMParticle/RNMParticle.mm
@@ -20,9 +20,10 @@
 @end
 
 // Forward declare so New Arch `logCommerceEvent` can use the same JS→native
-// product action mapping as `RCTConvert MPCommerceEvent:` (defined later in this file).
+// mappings as `RCTConvert (MPCommerceEvent)` (defined later in this file).
 @interface RCTConvert (MPCommerceEvent)
 + (MPCommerceEventAction)MPCommerceEventAction:(id)json;
++ (MPPromotionAction)MPPromotionAction:(id)json;
 @end
 
 @implementation RNMParticle
@@ -457,7 +458,10 @@ RCT_EXPORT_METHOD(getSession:(RCTResponseSenderBlock)completion)
     }
 
     if (commerceEvent.promotionActionType().has_value()) {
-        mpCommerceEvent.promotionContainer = [[MPPromotionContainer alloc] initWithAction:(MPPromotionAction)commerceEvent.promotionActionType().value() promotion:nil];
+        MPPromotionAction promotionAction =
+            [RCTConvert MPPromotionAction:@(commerceEvent.promotionActionType().value())];
+        mpCommerceEvent.promotionContainer =
+            [[MPPromotionContainer alloc] initWithAction:promotionAction promotion:nil];
     }
 
     if (commerceEvent.products().has_value()) {
@@ -926,6 +930,7 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
 + (MPTransactionAttributes *)MPTransactionAttributes:(id)json;
 + (MPProduct *)MPProduct:(id)json;
 + (MPCommerceEventAction)MPCommerceEventAction:(id)json;
++ (MPPromotionAction)MPPromotionAction:(id)json;
 + (MPIdentityApiRequest *)MPIdentityApiRequest:(id)json;
 + (MPIdentityApiResult *)MPIdentityApiResult:(id)json;
 + (MPAliasRequest *)MPAliasRequest:(id)json;
@@ -995,7 +1000,7 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
 }
 
 + (MPPromotionContainer *)MPPromotionContainer:(id)json {
-    MPPromotionAction promotionAction = (MPPromotionAction)[json[@"promotionActionType"] intValue];
+    MPPromotionAction promotionAction = [RCTConvert MPPromotionAction:json[@"promotionActionType"]];
     MPPromotionContainer *promotionContainer = [[MPPromotionContainer alloc] initWithAction:promotionAction promotion:nil];
     NSArray *jsonPromotions = json[@"promotions"];
     [jsonPromotions enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
@@ -1043,6 +1048,20 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
         [product setObject:value forKeyedSubscript:key];
     }
     return product;
+}
+
++ (MPPromotionAction)MPPromotionAction:(NSNumber *)json {
+    // JS `PromotionActionType`: View = 0, Click = 1 (js/index.tsx).
+    // Apple `MPPromotionAction`: Click = 0, View = 1 (MPPromotion.h).
+    switch ([json intValue]) {
+        case 0:
+            return MPPromotionActionView;
+        case 1:
+            return MPPromotionActionClick;
+        default:
+            // Match Android `convertPromotionActionType`: non-zero → Click
+            return MPPromotionActionClick;
+    }
 }
 
 + (MPCommerceEventAction)MPCommerceEventAction:(NSNumber *)json {


### PR DESCRIPTION
## Summary
On iOS with the New Architecture (RCT_NEW_ARCH_ENABLED), logCommerceEvent set MPCommerceEvent.action by casting the TurboModule / codegen number straight to MPCommerceEventAction. That number is the JavaScript ProductActionType (1-based MPReactCommerceEventAction: AddToCart = 1, …), which does not match the Apple SDK’s native enum raw values or ordering. The result was wrong commerce actions (e.g. AddToCart → remove_from_cart, and generally scrambled types including wishlist vs checkout).

The legacy bridge path already fixed this by routing productActionType through [RCTConvert MPCommerceEventAction:], which maps each JS constant to the correct MPCommerceEventAction.

This PR aligns the New Architecture path with that behavior by:

- Using [RCTConvert MPCommerceEventAction:@(productActionType)] in the New Arch logCommerceEvent implementation instead of a direct cast.
- Adding a forward declaration for + [RCTConvert MPCommerceEventAction:] near the top of RNMParticle.mm so the call is valid before the RCTConvert (MPCommerceEvent) category implementation later in the file.
- Updating RCTConvert (MParticle) + MPCommerceEvent: (dictionary-based helper) to set commerceEvent.action via MPCommerceEventAction: as well, instead of casting the integer directly—same bug class if that code path is used.
Android is unchanged (already maps JS ints explicitly in Kotlin). Promotion action types were not part of this issue (JS 0/1 matches existing native usage).

## Master Issue
Closes https://go.mparticle.com/work/TRIAGE-719
