### PR TITLE
chore(android): bump mParticle core/rokt-kit floor to 5.79.2 (carries roktsdk 4.14.5 deferred-init fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - iOS sample CI: pin `Rokt-Widget` to `5.2.0` and `DcuiSchema` to `2.7.0` (avoids `2.8.x` schema floating under Rokt’s `~> 2.6` and breaking `RoktUXHelper` Swift compile); GitHub Actions stays on Xcode 16.x
+- Android: raise the `com.mparticle:android-core` / `android-rokt-kit` dependency floor to `[5.79.2, 6.0)` (Expo plugin kit injection and bridge `android/build.gradle`), and bump the sample app to `5.79.2`. This guarantees consumers resolve a Rokt kit built against `com.rokt:roktsdk` `4.14.5`, which observes the Activity lifecycle from process start so overlay/bottom-sheet placements display even when `Rokt.init()` runs after the host Activity has resumed (deferred / late RN initialisation)
 
 ## [3.1.4] - 2026-06-05
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -120,7 +120,7 @@ dependencies {
     //
     // Bounded upper bound prevents resolving to 6.0.0-rc.1+ on Maven Central.
     // 6.x removed deprecated symbols (e.g. UserAttributeListener); see #710.
-    api 'com.mparticle:android-core:[5.79.0, 6.0)'
+    api 'com.mparticle:android-core:[5.79.2, 6.0)'
 
     //
     // And, if you want to include kits, you can do so as follows:
@@ -136,6 +136,6 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation files('libs/java-json.jar')
 
-    testImplementation 'com.mparticle:android-core:5.79.0'
+    testImplementation 'com.mparticle:android-core:5.79.2'
     testImplementation("com.facebook.react:react-android:+")
 }

--- a/plugin/src/withMParticleAndroid.ts
+++ b/plugin/src/withMParticleAndroid.ts
@@ -385,7 +385,7 @@ const withMParticleAppBuildGradle: ConfigPlugin<MParticlePluginProps> = (
     // to a pre-release (e.g. 6.0.0-rc.1) and transitively drag the core past
     // the bridge's compiled-against API surface.
     const kitDependencies = props.androidKits
-      .map(kit => `    implementation "com.mparticle:${kit}:[5.79.0, 6.0)"`)
+      .map(kit => `    implementation "com.mparticle:${kit}:[5.79.2, 6.0)"`)
       .join('\n');
 
     // Use mergeContents for idempotent injection

--- a/sample/README.md
+++ b/sample/README.md
@@ -67,7 +67,7 @@ pod install
 The sample Podfile pins `mParticle-Rokt` `~> 9.2`, **`Rokt-Widget` `5.2.0`**, and **`DcuiSchema` `2.7.0`**. Rokt’s pods allow `DcuiSchema` to float within `~> 2.6`; when CocoaPods resolves **2.8.0+**, the schema adds `image` styling that can desync from the `RoktUXHelper` sources in that widget line and break Swift compile (`StyleTransformer` / `BaseStyles`). Bump these pins together when you adopt a newer Rokt iOS stack.
 
 The sample Android app pins `com.mparticle:android-core` and
-`com.mparticle:android-rokt-kit` to `5.79.0` so the Rokt session APIs and
+`com.mparticle:android-rokt-kit` to `5.79.2` so the Rokt session APIs and
 Android CNAME support are available. Payment-extension installation and native
 URL callback forwarding are not configured in this release.
 

--- a/sample/android/app/build.gradle
+++ b/sample/android/app/build.gradle
@@ -110,8 +110,8 @@ android {
 dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
-    implementation("com.mparticle:android-core:5.79.0")
-    implementation("com.mparticle:android-rokt-kit:5.79.0")
+    implementation("com.mparticle:android-core:5.79.2")
+    implementation("com.mparticle:android-rokt-kit:5.79.2")
 
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")


### PR DESCRIPTION
## Summary

Raises the mParticle Android dependency floor to **`[5.79.2, 6.0)`** and bumps the sample app to **`5.79.2`**, so React Native consumers resolve a Rokt kit built against `com.rokt:roktsdk 4.14.5`.

| Location | Before | After |
|---|---|---|
| Expo plugin kit injection (`plugin/src/withMParticleAndroid.ts`) | `[5.79.0, 6.0)` | `[5.79.2, 6.0)` |
| Bridge core (`android/build.gradle`, `api` + test pin) | `5.79.0` | `5.79.2` |
| Sample app (`sample/android/app/build.gradle`) | `android-core` / `android-rokt-kit` `5.79.0` | `5.79.2` |

## Why

`com.mparticle:android-rokt-kit:5.79.2` is the first kit built against **`com.rokt:roktsdk 4.14.5`**, which fixes overlay/bottom-sheet placements failing on **late/deferred `Rokt.init()`** — the exact React Native + mParticle scenario (async kit load / deferred first-frame init) where the SDK initialised after the host Activity had already resumed and the cached Activity stayed `null`. `4.14.5` observes the Activity lifecycle from process start (via a no-op `ContentProvider`) and recovers the host Activity from the Compose context.

Chain: [ROKT/sdk-android-source#1087](https://github.com/ROKT/sdk-android-source/pull/1087) (roktsdk 4.14.5, released) → [mparticle-integrations/mparticle-android-integration-rokt#146](https://github.com/mparticle-integrations/mparticle-android-integration-rokt/pull/146) (kit pin bump) → mParticle Android SDK 5.79.2 release → **this PR**.

The bounded upper bound (`< 6.0`) is unchanged — it keeps kit + core paired on the 5.x line and avoids resolving `6.0.0-rc.1`, consistent with the existing comments and #710.

## ⚠️ Merge ordering

**This PR is gated on `mParticle/mparticle-android-sdk` 5.79.2 publishing `android-core` + `android-rokt-kit` `5.79.2` to Maven Central.** Until then, Android CI will fail to resolve `[5.79.2, 6.0)` (5.79.1 is below the floor and 6.0.0-rc.1 is excluded). Do not merge before 5.79.2 is live; re-run CI once it is.

## Notes

- Plugin source only (`plugin/build` is gitignored); no compiled output to update.
- Docs that read "`5.79.0` or newer" describe other feature minimums (CNAME / session APIs) and remain accurate, so they're intentionally left unchanged.
- No npm version bump here — the repo's release workflow handles versioning from the `[Unreleased]` CHANGELOG section.
