### PR TITLE
feat: expose device-based consent APIs in React Native bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Expose device-level consent APIs: `setDeviceConsentState`, `clearDeviceConsentState`, and `getDeviceConsentState`, bridging to native `MParticle.deviceConsentState` (iOS) and `MParticle.setDeviceConsentState()` (Android). Requires mParticle Apple SDK 9.2+ with device consent; Android resolves `android-core` `[5.79.2, 6.0)` and picks up device consent APIs once published.
+
 - Expo config plugin: optional `pinningDisabled` for `MPNetworkOptions` / `NetworkOptions` at SDK startup
 
 ### Fixed

--- a/android/src/main/java/com/mparticle/react/MParticleModule.kt
+++ b/android/src/main/java/com/mparticle/react/MParticleModule.kt
@@ -534,6 +534,30 @@ class MParticleModule(
         }
     }
 
+    @ReactMethod
+    override fun setDeviceConsentState(consentState: ReadableMap?) {
+        val instance = MParticle.getInstance() ?: return
+        if (consentState == null) {
+            return
+        }
+        convertToConsentState(consentState)?.let { instance.setDeviceConsentState(it) }
+    }
+
+    @ReactMethod
+    override fun clearDeviceConsentState() {
+        MParticle.getInstance()?.setDeviceConsentState(null)
+    }
+
+    @ReactMethod
+    override fun getDeviceConsentState(callback: Callback) {
+        val instance = MParticle.getInstance()
+        if (instance == null) {
+            callback.invoke(null)
+            return
+        }
+        callback.invoke(consentStateToMap(instance.getDeviceConsentState()))
+    }
+
     protected fun getWritableMap(): WritableMap = WritableNativeMap()
 
     private fun convertIdentityAPIRequest(map: ReadableMap?): IdentityApiRequest {
@@ -972,5 +996,61 @@ class MParticleModule(
             }
         }
         return builder.build()
+    }
+
+    private fun convertToConsentState(map: ReadableMap): ConsentState? {
+        val builder = ConsentState.builder()
+        if (map.hasKey("gdpr")) {
+            val gdprMap = map.getMap("gdpr") ?: return null
+            val iterator = gdprMap.keySetIterator()
+            while (iterator.hasNextKey()) {
+                val purpose = iterator.nextKey()
+                val consentMap = gdprMap.getMap(purpose) ?: continue
+                convertToGDPRConsent(consentMap)?.let { builder.addGDPRConsentState(purpose, it) }
+            }
+        }
+        if (map.hasKey("ccpa")) {
+            map.getMap("ccpa")?.let { ccpaMap ->
+                convertToCCPAConsent(ccpaMap)?.let { builder.setCCPAConsentState(it) }
+            }
+        }
+        return builder.build()
+    }
+
+    private fun consentStateToMap(state: ConsentState?): WritableMap? {
+        if (state == null) {
+            return null
+        }
+        val result = Arguments.createMap()
+        val gdprConsentState = state.gdprConsentState
+        if (gdprConsentState.isNotEmpty()) {
+            val gdprMap = Arguments.createMap()
+            for ((purpose, consent) in gdprConsentState) {
+                gdprMap.putMap(purpose, gdprConsentToMap(consent))
+            }
+            result.putMap("gdpr", gdprMap)
+        }
+        state.ccpaConsentState?.let { result.putMap("ccpa", ccpaConsentToMap(it)) }
+        return if (result.toHashMap().isEmpty()) null else result
+    }
+
+    private fun gdprConsentToMap(consent: GDPRConsent): WritableMap {
+        val map = Arguments.createMap()
+        map.putBoolean("consented", consent.isConsented)
+        consent.document?.let { map.putString("document", it) }
+        consent.location?.let { map.putString("location", it) }
+        consent.hardwareId?.let { map.putString("hardwareId", it) }
+        consent.timestamp?.let { map.putDouble("timestamp", it.toDouble()) }
+        return map
+    }
+
+    private fun ccpaConsentToMap(consent: CCPAConsent): WritableMap {
+        val map = Arguments.createMap()
+        map.putBoolean("consented", consent.isConsented)
+        consent.document?.let { map.putString("document", it) }
+        consent.location?.let { map.putString("location", it) }
+        consent.hardwareId?.let { map.putString("hardwareId", it) }
+        consent.timestamp?.let { map.putDouble("timestamp", it.toDouble()) }
+        return map
     }
 }

--- a/android/src/main/java/com/mparticle/react/MParticleModule.kt
+++ b/android/src/main/java/com/mparticle/react/MParticleModule.kt
@@ -1001,12 +1001,13 @@ class MParticleModule(
     private fun convertToConsentState(map: ReadableMap): ConsentState? {
         val builder = ConsentState.builder()
         if (map.hasKey("gdpr")) {
-            val gdprMap = map.getMap("gdpr") ?: return null
-            val iterator = gdprMap.keySetIterator()
-            while (iterator.hasNextKey()) {
-                val purpose = iterator.nextKey()
-                val consentMap = gdprMap.getMap(purpose) ?: continue
-                convertToGDPRConsent(consentMap)?.let { builder.addGDPRConsentState(purpose, it) }
+            map.getMap("gdpr")?.let { gdprMap ->
+                val iterator = gdprMap.keySetIterator()
+                while (iterator.hasNextKey()) {
+                    val purpose = iterator.nextKey()
+                    val consentMap = gdprMap.getMap(purpose) ?: continue
+                    convertToGDPRConsent(consentMap)?.let { builder.addGDPRConsentState(purpose, it) }
+                }
             }
         }
         if (map.hasKey("ccpa")) {

--- a/android/src/main/java/com/mparticle/react/MParticleModule.kt
+++ b/android/src/main/java/com/mparticle/react/MParticleModule.kt
@@ -953,15 +953,28 @@ class MParticleModule(
             map.getString("location")?.let { builder.location(it) }
         }
         if (map.hasKey("timestamp")) {
-            try {
-                val timestampString = map.getString("timestamp")
-                val timestamp = timestampString?.toLong()
-                timestamp?.let { builder.timestamp(it) }
-            } catch (ex: Exception) {
-                Logger.warning("failed to convert \"timestamp\" value to Long")
-            }
+            readConsentTimestampMillis(map, "timestamp")?.let { builder.timestamp(it) }
         }
         return builder.build()
+    }
+
+    private fun readConsentTimestampMillis(
+        map: ReadableMap,
+        key: String,
+    ): Long? {
+        if (!map.hasKey(key)) {
+            return null
+        }
+        return try {
+            when (map.getType(key)) {
+                ReadableType.Number -> map.getDouble(key).toLong()
+                ReadableType.String -> map.getString(key)?.toLongOrNull()
+                else -> null
+            }
+        } catch (ex: Exception) {
+            Logger.warning("failed to convert \"$key\" timestamp value to Long")
+            null
+        }
     }
 
     private fun convertToCCPAConsent(map: ReadableMap): CCPAConsent? {
@@ -988,13 +1001,7 @@ class MParticleModule(
             map.getString("location")?.let { builder.location(it) }
         }
         if (map.hasKey("timestamp")) {
-            try {
-                val timestampString = map.getString("timestamp")
-                val timestamp = timestampString?.toLong()
-                timestamp?.let { builder.timestamp(it) }
-            } catch (ex: Exception) {
-                Logger.warning("failed to convert \"timestamp\" value to Long")
-            }
+            readConsentTimestampMillis(map, "timestamp")?.let { builder.timestamp(it) }
         }
         return builder.build()
     }

--- a/android/src/main/java/com/mparticle/react/MParticleModule.kt
+++ b/android/src/main/java/com/mparticle/react/MParticleModule.kt
@@ -540,7 +540,8 @@ class MParticleModule(
         if (consentState == null) {
             return
         }
-        convertToConsentState(consentState)?.let { instance.setDeviceConsentState(it) }
+        val state = convertToConsentState(consentState)
+        instance.setDeviceConsentState(if (isEmptyConsentState(state)) null else state)
     }
 
     @ReactMethod
@@ -998,7 +999,7 @@ class MParticleModule(
         return builder.build()
     }
 
-    private fun convertToConsentState(map: ReadableMap): ConsentState? {
+    private fun convertToConsentState(map: ReadableMap): ConsentState {
         val builder = ConsentState.builder()
         if (map.hasKey("gdpr")) {
             map.getMap("gdpr")?.let { gdprMap ->
@@ -1017,6 +1018,8 @@ class MParticleModule(
         }
         return builder.build()
     }
+
+    private fun isEmptyConsentState(state: ConsentState) = state.gdprConsentState.isEmpty() && state.ccpaConsentState == null
 
     private fun consentStateToMap(state: ConsentState?): WritableMap? {
         if (state == null) {

--- a/android/src/oldarch/java/com/mparticle/react/NativeMParticleSpec.kt
+++ b/android/src/oldarch/java/com/mparticle/react/NativeMParticleSpec.kt
@@ -57,6 +57,12 @@ abstract class NativeMParticleSpec(
 
     abstract fun removeCCPAConsentState()
 
+    abstract fun setDeviceConsentState(consentState: ReadableMap?)
+
+    abstract fun clearDeviceConsentState()
+
+    abstract fun getDeviceConsentState(callback: Callback)
+
     abstract fun isKitActive(
         kitId: Double,
         callback: Callback,

--- a/ios/RNMParticle/RNMParticle.mm
+++ b/ios/RNMParticle/RNMParticle.mm
@@ -613,7 +613,8 @@ RCT_EXPORT_METHOD(getSession:(RCTResponseSenderBlock)completion)
         callback(@[[NSNull null]]);
         return;
     }
-    callback(@[[RNMParticle consentStateToDictionary:deviceConsent]]);
+    NSDictionary *consentDict = [RNMParticle consentStateToDictionary:deviceConsent];
+    callback(@[consentDict ?: [NSNull null]]);
 }
 #else
 
@@ -665,7 +666,8 @@ RCT_EXPORT_METHOD(getDeviceConsentState:(RCTResponseSenderBlock)callback)
         callback(@[[NSNull null]]);
         return;
     }
-    callback(@[[RNMParticle consentStateToDictionary:deviceConsent]]);
+    NSDictionary *consentDict = [RNMParticle consentStateToDictionary:deviceConsent];
+    callback(@[consentDict ?: [NSNull null]]);
 }
 
 #endif

--- a/ios/RNMParticle/RNMParticle.mm
+++ b/ios/RNMParticle/RNMParticle.mm
@@ -31,6 +31,14 @@
 + (MPConsentState *)MPConsentState:(id)json;
 @end
 
+static BOOL RNMParticleIsEmptyConsentState(MPConsentState *state)
+{
+    if (state == nil) {
+        return YES;
+    }
+    return state.gdprConsentState.count == 0 && state.ccpaConsentState == nil;
+}
+
 @implementation RNMParticle
 
 RCT_EXTERN void RCTRegisterModule(Class);
@@ -600,7 +608,8 @@ RCT_EXPORT_METHOD(getSession:(RCTResponseSenderBlock)completion)
     if (ccpa != nil && ccpa != [NSNull null]) {
         dict[@"ccpa"] = ccpa;
     }
-    [MParticle sharedInstance].deviceConsentState = [RCTConvert MPConsentState:dict];
+    MPConsentState *state = [RCTConvert MPConsentState:dict];
+    [MParticle sharedInstance].deviceConsentState = RNMParticleIsEmptyConsentState(state) ? nil : state;
 }
 
 - (void)clearDeviceConsentState {
@@ -651,7 +660,8 @@ RCT_EXPORT_METHOD(setDeviceConsentState:(NSDictionary *)consentState)
     if (consentState == nil || consentState == (id)[NSNull null]) {
         return;
     }
-    [MParticle sharedInstance].deviceConsentState = [RCTConvert MPConsentState:consentState];
+    MPConsentState *state = [RCTConvert MPConsentState:consentState];
+    [MParticle sharedInstance].deviceConsentState = RNMParticleIsEmptyConsentState(state) ? nil : state;
 }
 
 RCT_EXPORT_METHOD(clearDeviceConsentState)

--- a/ios/RNMParticle/RNMParticle.mm
+++ b/ios/RNMParticle/RNMParticle.mm
@@ -40,27 +40,6 @@ static BOOL RNMParticleIsEmptyConsentState(MPConsentState *state)
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED
-static NSMutableDictionary *RNMParticleGDPRConsentStructToDict(const JS::NativeMParticle::GDPRConsent &consent)
-{
-    NSMutableDictionary *consentDict = [NSMutableDictionary dictionary];
-    if (consent.consented().has_value()) {
-        consentDict[@"consented"] = @(consent.consented().value());
-    }
-    if (consent.document()) {
-        consentDict[@"document"] = consent.document();
-    }
-    if (consent.timestamp().has_value()) {
-        consentDict[@"timestamp"] = @(consent.timestamp().value());
-    }
-    if (consent.location()) {
-        consentDict[@"location"] = consent.location();
-    }
-    if (consent.hardwareId()) {
-        consentDict[@"hardwareId"] = consent.hardwareId();
-    }
-    return consentDict;
-}
-
 static NSMutableDictionary *RNMParticleCCPAConsentStructToDict(const JS::NativeMParticle::CCPAConsent &consent)
 {
     NSMutableDictionary *consentDict = [NSMutableDictionary dictionary];
@@ -644,13 +623,9 @@ RCT_EXPORT_METHOD(getSession:(RCTResponseSenderBlock)completion)
 
 - (void)setDeviceConsentState:(JS::NativeMParticle::DeviceConsentState &)consentState {
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
-    if (consentState.gdpr().has_value()) {
-        NSMutableDictionary *gdprDict = [NSMutableDictionary dictionary];
-        for (const auto &entry : consentState.gdpr().value()) {
-            gdprDict[[NSString stringWithUTF8String:entry.first.c_str()]] =
-                RNMParticleGDPRConsentStructToDict(entry.second);
-        }
-        dict[@"gdpr"] = gdprDict;
+    id gdpr = consentState.gdpr();
+    if (gdpr != nil && gdpr != (id)[NSNull null]) {
+        dict[@"gdpr"] = gdpr;
     }
     if (consentState.ccpa().has_value()) {
         dict[@"ccpa"] = RNMParticleCCPAConsentStructToDict(consentState.ccpa().value());

--- a/ios/RNMParticle/RNMParticle.mm
+++ b/ios/RNMParticle/RNMParticle.mm
@@ -39,6 +39,50 @@ static BOOL RNMParticleIsEmptyConsentState(MPConsentState *state)
     return state.gdprConsentState.count == 0 && state.ccpaConsentState == nil;
 }
 
+#ifdef RCT_NEW_ARCH_ENABLED
+static NSMutableDictionary *RNMParticleGDPRConsentStructToDict(const JS::NativeMParticle::GDPRConsent &consent)
+{
+    NSMutableDictionary *consentDict = [NSMutableDictionary dictionary];
+    if (consent.consented().has_value()) {
+        consentDict[@"consented"] = @(consent.consented().value());
+    }
+    if (consent.document()) {
+        consentDict[@"document"] = consent.document();
+    }
+    if (consent.timestamp().has_value()) {
+        consentDict[@"timestamp"] = @(consent.timestamp().value());
+    }
+    if (consent.location()) {
+        consentDict[@"location"] = consent.location();
+    }
+    if (consent.hardwareId()) {
+        consentDict[@"hardwareId"] = consent.hardwareId();
+    }
+    return consentDict;
+}
+
+static NSMutableDictionary *RNMParticleCCPAConsentStructToDict(const JS::NativeMParticle::CCPAConsent &consent)
+{
+    NSMutableDictionary *consentDict = [NSMutableDictionary dictionary];
+    if (consent.consented().has_value()) {
+        consentDict[@"consented"] = @(consent.consented().value());
+    }
+    if (consent.document()) {
+        consentDict[@"document"] = consent.document();
+    }
+    if (consent.timestamp().has_value()) {
+        consentDict[@"timestamp"] = @(consent.timestamp().value());
+    }
+    if (consent.location()) {
+        consentDict[@"location"] = consent.location();
+    }
+    if (consent.hardwareId()) {
+        consentDict[@"hardwareId"] = consent.hardwareId();
+    }
+    return consentDict;
+}
+#endif
+
 @implementation RNMParticle
 
 RCT_EXTERN void RCTRegisterModule(Class);
@@ -600,13 +644,16 @@ RCT_EXPORT_METHOD(getSession:(RCTResponseSenderBlock)completion)
 
 - (void)setDeviceConsentState:(JS::NativeMParticle::DeviceConsentState &)consentState {
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
-    id gdpr = consentState.gdpr();
-    if (gdpr != nil && gdpr != [NSNull null]) {
-        dict[@"gdpr"] = gdpr;
+    if (consentState.gdpr().has_value()) {
+        NSMutableDictionary *gdprDict = [NSMutableDictionary dictionary];
+        for (const auto &entry : consentState.gdpr().value()) {
+            gdprDict[[NSString stringWithUTF8String:entry.first.c_str()]] =
+                RNMParticleGDPRConsentStructToDict(entry.second);
+        }
+        dict[@"gdpr"] = gdprDict;
     }
-    id ccpa = consentState.ccpa();
-    if (ccpa != nil && ccpa != [NSNull null]) {
-        dict[@"ccpa"] = ccpa;
+    if (consentState.ccpa().has_value()) {
+        dict[@"ccpa"] = RNMParticleCCPAConsentStructToDict(consentState.ccpa().value());
     }
     MPConsentState *state = [RCTConvert MPConsentState:dict];
     [MParticle sharedInstance].deviceConsentState = RNMParticleIsEmptyConsentState(state) ? nil : state;
@@ -1361,7 +1408,7 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
     if ([gdpr isKindOfClass:[NSDictionary class]]) {
         for (NSString *purpose in gdpr) {
             id consentJson = gdpr[purpose];
-            if (consentJson == [NSNull null]) {
+            if (consentJson == [NSNull null] || ![consentJson isKindOfClass:[NSDictionary class]]) {
                 continue;
             }
             MPGDPRConsent *consent = [RCTConvert MPGDPRConsent:consentJson];
@@ -1372,7 +1419,7 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
     }
 
     id ccpaJson = dict[@"ccpa"];
-    if (ccpaJson != nil && ccpaJson != [NSNull null]) {
+    if (ccpaJson != nil && ccpaJson != [NSNull null] && [ccpaJson isKindOfClass:[NSDictionary class]]) {
         MPCCPAConsent *ccpa = [RCTConvert MPCCPAConsent:ccpaJson];
         if (ccpa != nil) {
             [state setCCPAConsentState:ccpa];

--- a/ios/RNMParticle/RNMParticle.mm
+++ b/ios/RNMParticle/RNMParticle.mm
@@ -1316,7 +1316,9 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
 
     mpConsent.consented = [RCTConvert BOOL:json[@"consented"]];
     mpConsent.document = json[@"document"];
-    mpConsent.timestamp = [RCTConvert NSDate:json[@"timestamp"]];
+    if (json[@"timestamp"] && json[@"timestamp"] != [NSNull null]) {
+        mpConsent.timestamp = [NSDate dateWithTimeIntervalSince1970:[json[@"timestamp"] doubleValue] / 1000.0];
+    }
     mpConsent.location = json[@"location"];
     mpConsent.hardwareId = json[@"hardwareId"];
 
@@ -1328,7 +1330,9 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
 
     mpConsent.consented = [RCTConvert BOOL:json[@"consented"]];
     mpConsent.document = json[@"document"];
-    mpConsent.timestamp = [RCTConvert NSDate:json[@"timestamp"]];
+    if (json[@"timestamp"] && json[@"timestamp"] != [NSNull null]) {
+        mpConsent.timestamp = [NSDate dateWithTimeIntervalSince1970:[json[@"timestamp"] doubleValue] / 1000.0];
+    }
     mpConsent.location = json[@"location"];
     mpConsent.hardwareId = json[@"hardwareId"];
 

--- a/ios/RNMParticle/RNMParticle.mm
+++ b/ios/RNMParticle/RNMParticle.mm
@@ -24,6 +24,7 @@
 @interface RCTConvert (MPCommerceEvent)
 + (MPCommerceEventAction)MPCommerceEventAction:(id)json;
 + (MPPromotionAction)MPPromotionAction:(id)json;
++ (MPConsentState *)MPConsentState:(id)json;
 @end
 
 @implementation RNMParticle

--- a/ios/RNMParticle/RNMParticle.mm
+++ b/ios/RNMParticle/RNMParticle.mm
@@ -108,6 +108,29 @@ RCT_EXPORT_METHOD(removeCCPAConsentState)
     user.consentState = consentState;
 }
 
+RCT_EXPORT_METHOD(setDeviceConsentState:(NSDictionary *)consentState)
+{
+    if (consentState == nil || consentState == (id)[NSNull null]) {
+        return;
+    }
+    [MParticle sharedInstance].deviceConsentState = [RCTConvert MPConsentState:consentState];
+}
+
+RCT_EXPORT_METHOD(clearDeviceConsentState)
+{
+    [MParticle sharedInstance].deviceConsentState = nil;
+}
+
+RCT_EXPORT_METHOD(getDeviceConsentState:(RCTResponseSenderBlock)callback)
+{
+    MPConsentState *deviceConsent = [MParticle sharedInstance].deviceConsentState;
+    if (deviceConsent == nil) {
+        callback(@[[NSNull null]]);
+        return;
+    }
+    callback(@[[RNMParticle consentStateToDictionary:deviceConsent]]);
+}
+
 #if TARGET_OS_IOS == 1
 RCT_EXPORT_METHOD(logPushRegistration:(NSString *)token senderId:(NSString *)senderId)
 {
@@ -584,6 +607,68 @@ RCT_EXPORT_METHOD(getSession:(RCTResponseSenderBlock)completion)
     [consentState setCCPAConsentState:ccpaConsent];
     user.consentState = consentState;
 }
+
+- (void)setDeviceConsentState:(JS::NativeMParticle::DeviceConsentState &)consentState {
+    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+    if (consentState.gdpr().has_value()) {
+        NSMutableDictionary *gdprDict = [NSMutableDictionary dictionary];
+        for (const auto &entry : consentState.gdpr().value()) {
+            const auto &consent = entry.second;
+            NSMutableDictionary *consentDict = [NSMutableDictionary dictionary];
+            if (consent.consented().has_value()) {
+                consentDict[@"consented"] = @(consent.consented().value());
+            }
+            if (consent.document()) {
+                consentDict[@"document"] = consent.document();
+            }
+            if (consent.timestamp().has_value()) {
+                consentDict[@"timestamp"] = @(consent.timestamp().value());
+            }
+            if (consent.location()) {
+                consentDict[@"location"] = consent.location();
+            }
+            if (consent.hardwareId()) {
+                consentDict[@"hardwareId"] = consent.hardwareId();
+            }
+            gdprDict[[NSString stringWithUTF8String:entry.first.c_str()]] = consentDict;
+        }
+        dict[@"gdpr"] = gdprDict;
+    }
+    if (consentState.ccpa().has_value()) {
+        const auto &ccpa = consentState.ccpa().value();
+        NSMutableDictionary *ccpaDict = [NSMutableDictionary dictionary];
+        if (ccpa.consented().has_value()) {
+            ccpaDict[@"consented"] = @(ccpa.consented().value());
+        }
+        if (ccpa.document()) {
+            ccpaDict[@"document"] = ccpa.document();
+        }
+        if (ccpa.timestamp().has_value()) {
+            ccpaDict[@"timestamp"] = @(ccpa.timestamp().value());
+        }
+        if (ccpa.location()) {
+            ccpaDict[@"location"] = ccpa.location();
+        }
+        if (ccpa.hardwareId()) {
+            ccpaDict[@"hardwareId"] = ccpa.hardwareId();
+        }
+        dict[@"ccpa"] = ccpaDict;
+    }
+    [MParticle sharedInstance].deviceConsentState = [RCTConvert MPConsentState:dict];
+}
+
+- (void)clearDeviceConsentState {
+    [MParticle sharedInstance].deviceConsentState = nil;
+}
+
+- (void)getDeviceConsentState:(RCTResponseSenderBlock)callback {
+    MPConsentState *deviceConsent = [MParticle sharedInstance].deviceConsentState;
+    if (deviceConsent == nil) {
+        callback(@[[NSNull null]]);
+        return;
+    }
+    callback(@[[RNMParticle consentStateToDictionary:deviceConsent]]);
+}
 #else
 
 RCT_EXPORT_METHOD(logMPEvent:(MPEvent *)event)
@@ -907,6 +992,59 @@ RCT_EXPORT_METHOD(setCCPAConsentState:(MPCCPAConsent *)consent)
     return [MPAliasRequest requestWithSourceMPID:sourceMpid destinationMPID:destinationMpid startTime:startTime endTime:endTime];
 }
 
++ (NSDictionary *)consentStateToDictionary:(MPConsentState *)consentState
+{
+    if (consentState == nil) {
+        return nil;
+    }
+
+    NSMutableDictionary *result = [NSMutableDictionary dictionary];
+    NSDictionary<NSString *, MPGDPRConsent *> *gdprState = consentState.gdprConsentState;
+    if (gdprState.count > 0) {
+        NSMutableDictionary *gdpr = [NSMutableDictionary dictionaryWithCapacity:gdprState.count];
+        for (NSString *purpose in gdprState) {
+            MPGDPRConsent *consent = gdprState[purpose];
+            NSMutableDictionary *consentDict = [NSMutableDictionary dictionary];
+            consentDict[@"consented"] = @(consent.consented);
+            if (consent.document) {
+                consentDict[@"document"] = consent.document;
+            }
+            if (consent.timestamp) {
+                consentDict[@"timestamp"] = @((long long)([consent.timestamp timeIntervalSince1970] * 1000));
+            }
+            if (consent.location) {
+                consentDict[@"location"] = consent.location;
+            }
+            if (consent.hardwareId) {
+                consentDict[@"hardwareId"] = consent.hardwareId;
+            }
+            gdpr[purpose] = consentDict;
+        }
+        result[@"gdpr"] = gdpr;
+    }
+
+    MPCCPAConsent *ccpa = consentState.ccpaConsentState;
+    if (ccpa != nil) {
+        NSMutableDictionary *ccpaDict = [NSMutableDictionary dictionary];
+        ccpaDict[@"consented"] = @(ccpa.consented);
+        if (ccpa.document) {
+            ccpaDict[@"document"] = ccpa.document;
+        }
+        if (ccpa.timestamp) {
+            ccpaDict[@"timestamp"] = @((long long)([ccpa.timestamp timeIntervalSince1970] * 1000));
+        }
+        if (ccpa.location) {
+            ccpaDict[@"location"] = ccpa.location;
+        }
+        if (ccpa.hardwareId) {
+            ccpaDict[@"hardwareId"] = ccpa.hardwareId;
+        }
+        result[@"ccpa"] = ccpaDict;
+    }
+
+    return result.count > 0 ? result : nil;
+}
+
 @end
 
 typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
@@ -938,6 +1076,7 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
 + (MPEvent *)MPEvent:(id)json;
 + (MPGDPRConsent *)MPGDPRConsent:(id)json;
 + (MPCCPAConsent *)MPCCPAConsent:(id)json;
++ (MPConsentState *)MPConsentState:(id)json;
 
 @end
 
@@ -1223,6 +1362,39 @@ typedef NS_ENUM(NSUInteger, MPReactCommerceEventAction) {
     mpConsent.hardwareId = json[@"hardwareId"];
 
     return mpConsent;
+}
+
++ (MPConsentState *)MPConsentState:(id)json
+{
+    if (![json isKindOfClass:[NSDictionary class]]) {
+        return nil;
+    }
+
+    NSDictionary *dict = (NSDictionary *)json;
+    MPConsentState *state = [[MPConsentState alloc] init];
+    NSDictionary *gdpr = dict[@"gdpr"];
+    if ([gdpr isKindOfClass:[NSDictionary class]]) {
+        for (NSString *purpose in gdpr) {
+            id consentJson = gdpr[purpose];
+            if (consentJson == [NSNull null]) {
+                continue;
+            }
+            MPGDPRConsent *consent = [RCTConvert MPGDPRConsent:consentJson];
+            if (consent != nil) {
+                [state addGDPRConsentState:consent purpose:purpose];
+            }
+        }
+    }
+
+    id ccpaJson = dict[@"ccpa"];
+    if (ccpaJson != nil && ccpaJson != [NSNull null]) {
+        MPCCPAConsent *ccpa = [RCTConvert MPCCPAConsent:ccpaJson];
+        if (ccpa != nil) {
+            [state setCCPAConsentState:ccpa];
+        }
+    }
+
+    return state;
 }
 
 @end

--- a/ios/RNMParticle/RNMParticle.mm
+++ b/ios/RNMParticle/RNMParticle.mm
@@ -19,6 +19,10 @@
 - (void)setUserId:(NSNumber *)userId;
 @end
 
+@interface RNMParticle (DeviceConsent)
++ (NSDictionary *)consentStateToDictionary:(MPConsentState *)consentState;
+@end
+
 // Forward declare so New Arch `logCommerceEvent` can use the same JS→native
 // mappings as `RCTConvert (MPCommerceEvent)` (defined later in this file).
 @interface RCTConvert (MPCommerceEvent)
@@ -107,29 +111,6 @@ RCT_EXPORT_METHOD(removeCCPAConsentState)
     MPConsentState *consentState = user.consentState ? user.consentState : [[MPConsentState alloc] init];
     [consentState removeCCPAConsentState];
     user.consentState = consentState;
-}
-
-RCT_EXPORT_METHOD(setDeviceConsentState:(NSDictionary *)consentState)
-{
-    if (consentState == nil || consentState == (id)[NSNull null]) {
-        return;
-    }
-    [MParticle sharedInstance].deviceConsentState = [RCTConvert MPConsentState:consentState];
-}
-
-RCT_EXPORT_METHOD(clearDeviceConsentState)
-{
-    [MParticle sharedInstance].deviceConsentState = nil;
-}
-
-RCT_EXPORT_METHOD(getDeviceConsentState:(RCTResponseSenderBlock)callback)
-{
-    MPConsentState *deviceConsent = [MParticle sharedInstance].deviceConsentState;
-    if (deviceConsent == nil) {
-        callback(@[[NSNull null]]);
-        return;
-    }
-    callback(@[[RNMParticle consentStateToDictionary:deviceConsent]]);
 }
 
 #if TARGET_OS_IOS == 1
@@ -611,49 +592,13 @@ RCT_EXPORT_METHOD(getSession:(RCTResponseSenderBlock)completion)
 
 - (void)setDeviceConsentState:(JS::NativeMParticle::DeviceConsentState &)consentState {
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
-    if (consentState.gdpr().has_value()) {
-        NSMutableDictionary *gdprDict = [NSMutableDictionary dictionary];
-        for (const auto &entry : consentState.gdpr().value()) {
-            const auto &consent = entry.second;
-            NSMutableDictionary *consentDict = [NSMutableDictionary dictionary];
-            if (consent.consented().has_value()) {
-                consentDict[@"consented"] = @(consent.consented().value());
-            }
-            if (consent.document()) {
-                consentDict[@"document"] = consent.document();
-            }
-            if (consent.timestamp().has_value()) {
-                consentDict[@"timestamp"] = @(consent.timestamp().value());
-            }
-            if (consent.location()) {
-                consentDict[@"location"] = consent.location();
-            }
-            if (consent.hardwareId()) {
-                consentDict[@"hardwareId"] = consent.hardwareId();
-            }
-            gdprDict[[NSString stringWithUTF8String:entry.first.c_str()]] = consentDict;
-        }
-        dict[@"gdpr"] = gdprDict;
+    id gdpr = consentState.gdpr();
+    if (gdpr != nil && gdpr != [NSNull null]) {
+        dict[@"gdpr"] = gdpr;
     }
-    if (consentState.ccpa().has_value()) {
-        const auto &ccpa = consentState.ccpa().value();
-        NSMutableDictionary *ccpaDict = [NSMutableDictionary dictionary];
-        if (ccpa.consented().has_value()) {
-            ccpaDict[@"consented"] = @(ccpa.consented().value());
-        }
-        if (ccpa.document()) {
-            ccpaDict[@"document"] = ccpa.document();
-        }
-        if (ccpa.timestamp().has_value()) {
-            ccpaDict[@"timestamp"] = @(ccpa.timestamp().value());
-        }
-        if (ccpa.location()) {
-            ccpaDict[@"location"] = ccpa.location();
-        }
-        if (ccpa.hardwareId()) {
-            ccpaDict[@"hardwareId"] = ccpa.hardwareId();
-        }
-        dict[@"ccpa"] = ccpaDict;
+    id ccpa = consentState.ccpa();
+    if (ccpa != nil && ccpa != [NSNull null]) {
+        dict[@"ccpa"] = ccpa;
     }
     [MParticle sharedInstance].deviceConsentState = [RCTConvert MPConsentState:dict];
 }
@@ -698,6 +643,29 @@ RCT_EXPORT_METHOD(setCCPAConsentState:(MPCCPAConsent *)consent)
     MPConsentState *consentState = user.consentState ? user.consentState : [[MPConsentState alloc] init];
     [consentState setCCPAConsentState:consent];
     user.consentState = consentState;
+}
+
+RCT_EXPORT_METHOD(setDeviceConsentState:(NSDictionary *)consentState)
+{
+    if (consentState == nil || consentState == (id)[NSNull null]) {
+        return;
+    }
+    [MParticle sharedInstance].deviceConsentState = [RCTConvert MPConsentState:consentState];
+}
+
+RCT_EXPORT_METHOD(clearDeviceConsentState)
+{
+    [MParticle sharedInstance].deviceConsentState = nil;
+}
+
+RCT_EXPORT_METHOD(getDeviceConsentState:(RCTResponseSenderBlock)callback)
+{
+    MPConsentState *deviceConsent = [MParticle sharedInstance].deviceConsentState;
+    if (deviceConsent == nil) {
+        callback(@[[NSNull null]]);
+        return;
+    }
+    callback(@[[RNMParticle consentStateToDictionary:deviceConsent]]);
 }
 
 #endif
@@ -825,6 +793,59 @@ RCT_EXPORT_METHOD(setCCPAConsentState:(MPCCPAConsent *)consent)
     
     NSCharacterSet *keyCharacterSet = [NSCharacterSet characterSetWithCharactersInString:key];
     return [numericSet isSupersetOfSet:keyCharacterSet];
+}
+
++ (NSDictionary *)consentStateToDictionary:(MPConsentState *)consentState
+{
+    if (consentState == nil) {
+        return nil;
+    }
+
+    NSMutableDictionary *result = [NSMutableDictionary dictionary];
+    NSDictionary<NSString *, MPGDPRConsent *> *gdprState = consentState.gdprConsentState;
+    if (gdprState.count > 0) {
+        NSMutableDictionary *gdpr = [NSMutableDictionary dictionaryWithCapacity:gdprState.count];
+        for (NSString *purpose in gdprState) {
+            MPGDPRConsent *consent = gdprState[purpose];
+            NSMutableDictionary *consentDict = [NSMutableDictionary dictionary];
+            consentDict[@"consented"] = @(consent.consented);
+            if (consent.document) {
+                consentDict[@"document"] = consent.document;
+            }
+            if (consent.timestamp) {
+                consentDict[@"timestamp"] = @((long long)([consent.timestamp timeIntervalSince1970] * 1000));
+            }
+            if (consent.location) {
+                consentDict[@"location"] = consent.location;
+            }
+            if (consent.hardwareId) {
+                consentDict[@"hardwareId"] = consent.hardwareId;
+            }
+            gdpr[purpose] = consentDict;
+        }
+        result[@"gdpr"] = gdpr;
+    }
+
+    MPCCPAConsent *ccpa = consentState.ccpaConsentState;
+    if (ccpa != nil) {
+        NSMutableDictionary *ccpaDict = [NSMutableDictionary dictionary];
+        ccpaDict[@"consented"] = @(ccpa.consented);
+        if (ccpa.document) {
+            ccpaDict[@"document"] = ccpa.document;
+        }
+        if (ccpa.timestamp) {
+            ccpaDict[@"timestamp"] = @((long long)([ccpa.timestamp timeIntervalSince1970] * 1000));
+        }
+        if (ccpa.location) {
+            ccpaDict[@"location"] = ccpa.location;
+        }
+        if (ccpa.hardwareId) {
+            ccpaDict[@"hardwareId"] = ccpa.hardwareId;
+        }
+        result[@"ccpa"] = ccpaDict;
+    }
+
+    return result.count > 0 ? result : nil;
 }
 
 @end
@@ -991,59 +1012,6 @@ RCT_EXPORT_METHOD(setCCPAConsentState:(MPCCPAConsent *)consent)
     }
 
     return [MPAliasRequest requestWithSourceMPID:sourceMpid destinationMPID:destinationMpid startTime:startTime endTime:endTime];
-}
-
-+ (NSDictionary *)consentStateToDictionary:(MPConsentState *)consentState
-{
-    if (consentState == nil) {
-        return nil;
-    }
-
-    NSMutableDictionary *result = [NSMutableDictionary dictionary];
-    NSDictionary<NSString *, MPGDPRConsent *> *gdprState = consentState.gdprConsentState;
-    if (gdprState.count > 0) {
-        NSMutableDictionary *gdpr = [NSMutableDictionary dictionaryWithCapacity:gdprState.count];
-        for (NSString *purpose in gdprState) {
-            MPGDPRConsent *consent = gdprState[purpose];
-            NSMutableDictionary *consentDict = [NSMutableDictionary dictionary];
-            consentDict[@"consented"] = @(consent.consented);
-            if (consent.document) {
-                consentDict[@"document"] = consent.document;
-            }
-            if (consent.timestamp) {
-                consentDict[@"timestamp"] = @((long long)([consent.timestamp timeIntervalSince1970] * 1000));
-            }
-            if (consent.location) {
-                consentDict[@"location"] = consent.location;
-            }
-            if (consent.hardwareId) {
-                consentDict[@"hardwareId"] = consent.hardwareId;
-            }
-            gdpr[purpose] = consentDict;
-        }
-        result[@"gdpr"] = gdpr;
-    }
-
-    MPCCPAConsent *ccpa = consentState.ccpaConsentState;
-    if (ccpa != nil) {
-        NSMutableDictionary *ccpaDict = [NSMutableDictionary dictionary];
-        ccpaDict[@"consented"] = @(ccpa.consented);
-        if (ccpa.document) {
-            ccpaDict[@"document"] = ccpa.document;
-        }
-        if (ccpa.timestamp) {
-            ccpaDict[@"timestamp"] = @((long long)([ccpa.timestamp timeIntervalSince1970] * 1000));
-        }
-        if (ccpa.location) {
-            ccpaDict[@"location"] = ccpa.location;
-        }
-        if (ccpa.hardwareId) {
-            ccpaDict[@"hardwareId"] = ccpa.hardwareId;
-        }
-        result[@"ccpa"] = ccpaDict;
-    }
-
-    return result.count > 0 ? result : nil;
 }
 
 @end

--- a/js/codegenSpecs/NativeMParticle.ts
+++ b/js/codegenSpecs/NativeMParticle.ts
@@ -86,6 +86,11 @@ export interface CCPAConsent {
   hardwareId?: string | null;
 }
 
+export interface DeviceConsentState {
+  gdpr?: { [purpose: string]: GDPRConsent };
+  ccpa?: CCPAConsent | null;
+}
+
 export type AttributionResult = {
   [key: string]: {
     [key: string]: string | number | boolean;
@@ -139,6 +144,11 @@ export interface Spec extends TurboModule {
   removeGDPRConsentStateWithPurpose(purpose: string): void;
   setCCPAConsentState(consent: CCPAConsent): void;
   removeCCPAConsentState(): void;
+  setDeviceConsentState(consentState: DeviceConsentState): void;
+  clearDeviceConsentState(): void;
+  getDeviceConsentState(
+    callback: (result: DeviceConsentState | null) => void
+  ): void;
   isKitActive(kitId: number, callback: (result: boolean) => void): void;
   getAttributions(callback: (result: AttributionResult) => void): void;
   logPushRegistration(token: string, senderId: string): void;

--- a/js/index.tsx
+++ b/js/index.tsx
@@ -210,6 +210,27 @@ export const removeCCPAConsentState = (): void => {
   MParticleModule.removeCCPAConsentState();
 };
 
+export interface DeviceConsentState {
+  gdpr?: { [purpose: string]: GDPRConsent };
+  ccpa?: CCPAConsent | null;
+}
+
+export const setDeviceConsentState = (
+  consentState: DeviceConsentState
+): void => {
+  MParticleModule.setDeviceConsentState(consentState);
+};
+
+export const clearDeviceConsentState = (): void => {
+  MParticleModule.clearDeviceConsentState();
+};
+
+export const getDeviceConsentState = (
+  completion: CompletionCallback<DeviceConsentState | null>
+): void => {
+  MParticleModule.getDeviceConsentState(completion);
+};
+
 export const isKitActive = (
   kitId: number,
   completion: CompletionCallback<boolean>
@@ -930,6 +951,9 @@ const MParticle = {
   removeGDPRConsentStateWithPurpose,
   setCCPAConsentState,
   removeCCPAConsentState,
+  setDeviceConsentState,
+  clearDeviceConsentState,
+  getDeviceConsentState,
   isKitActive,
   getAttributions,
   logPushRegistration,

--- a/js/index.tsx
+++ b/js/index.tsx
@@ -13,6 +13,7 @@ import type {
   Spec as NativeMParticleInterface,
   CallbackError,
   UserAttributes as NativeUserAttributes,
+  DeviceConsentState,
 } from './codegenSpecs/NativeMParticle';
 import { getNativeModule } from './utils/architecture';
 
@@ -210,10 +211,7 @@ export const removeCCPAConsentState = (): void => {
   MParticleModule.removeCCPAConsentState();
 };
 
-export interface DeviceConsentState {
-  gdpr?: { [purpose: string]: GDPRConsent };
-  ccpa?: CCPAConsent | null;
-}
+export type { DeviceConsentState };
 
 export const setDeviceConsentState = (
   consentState: DeviceConsentState


### PR DESCRIPTION
# Add device-level consent state to React Native bridge

## Summary

Exposes **device-level consent** APIs in the React Native wrapper so apps can set, read, and clear device-scoped consent from JavaScript. Native device consent (added in mParticle Apple SDK and android-core) supersedes per-user/MPID consent when set — consent collected before login or across identity changes at checkout is retained on the device.

Bridges to:
- **iOS** — `MParticle.sharedInstance().deviceConsentState` (requires mParticle Apple SDK 9.2+ with device consent)
- **Android** — `MParticle.getInstance().setDeviceConsentState()` / `getDeviceConsentState()` (requires android-core release with device consent APIs; resolves via `[5.79.2, 6.0)`)

## What has changed

- Added `setDeviceConsentState`, `clearDeviceConsentState`, and `getDeviceConsentState` to the JS API and default export
- Wired TurboModule/codegen spec, Android `MParticleModule`, and iOS `RNMParticle` (old arch + new arch)
- Reused existing consent map converters on Android; added `RCTConvert MPConsentState:` and `consentStateToDictionary:` on iOS

## Sample code

```typescript
import {
  setDeviceConsentState,
  clearDeviceConsentState,
  getDeviceConsentState,
} from 'react-native-mparticle';

// Set device-wide consent (supersedes any per-user consent)
setDeviceConsentState({
  gdpr: {
    data_sharing: {
      consented: true,
      document: 'privacy_policy_v3',
      timestamp: Date.now(),
    },
  },
});

// Clear — reverts to user/MPID-level consent
clearDeviceConsentState();

// Read current device consent
getDeviceConsentState((state) => {
  console.log(state);
});
```

## Testing

- `./gradlew test` and `./gradlew ktlintCheck` pass on the Android module

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

Related Android PR: https://github.com/mParticle/mparticle-android-sdk/pull/726

Related iOS PR: https://github.com/mParticle/mparticle-apple-sdk/pull/784 (merged)