### PR TITLE
fix: Forward impression events instead of null events

### DIFF
--- a/ios/RNMParticle/RNMParticle.mm
+++ b/ios/RNMParticle/RNMParticle.mm
@@ -573,6 +573,37 @@ RCT_EXPORT_METHOD(getSession:(RCTResponseSenderBlock)completion)
         [mpCommerceEvent addProducts:productsArray];
     }
 
+    if (commerceEvent.impressions().has_value()) {
+        auto impressionsVector = commerceEvent.impressions().value();
+        for (size_t j = 0; j < impressionsVector.size(); j++) {
+            auto impressionStruct = impressionsVector[j];
+            NSString *listName = impressionStruct.impressionListName();
+            if (!listName) {
+                continue;
+            }
+            auto productsInImpression = impressionStruct.products();
+            for (size_t k = 0; k < productsInImpression.size(); k++) {
+                auto productStruct = productsInImpression[k];
+                NSMutableDictionary *productDict = [[NSMutableDictionary alloc] init];
+                if (productStruct.name()) productDict[@"name"] = productStruct.name();
+                if (productStruct.sku()) productDict[@"sku"] = productStruct.sku();
+                productDict[@"price"] = @(productStruct.price());
+                if (productStruct.quantity().has_value()) productDict[@"quantity"] = @(productStruct.quantity().value());
+                if (productStruct.brand()) productDict[@"brand"] = productStruct.brand();
+                if (productStruct.couponCode()) productDict[@"couponCode"] = productStruct.couponCode();
+                if (productStruct.position().has_value()) productDict[@"position"] = @(productStruct.position().value());
+                if (productStruct.category()) productDict[@"category"] = productStruct.category();
+                if (productStruct.variant()) productDict[@"variant"] = productStruct.variant();
+                if (productStruct.customAttributes()) productDict[@"customAttributes"] = productStruct.customAttributes();
+
+                MPProduct *product = [self createMPProductFromDict:productDict];
+                if (product) {
+                    [mpCommerceEvent addImpression:product listName:listName];
+                }
+            }
+        }
+    }
+
     if (commerceEvent.transactionAttributes().has_value()) {
         // Create transaction attributes from the struct
         auto transactionAttrs = commerceEvent.transactionAttributes().value();


### PR DESCRIPTION
## Summary
A customer reported that Impression events sent from React Native SDK are being received as null in the UI, after further investigation it seems the iOS react native bridge was missing the logic to handle impressions in logCommerceEvents.

## Testing Plan
Tested E2E by changing the code locally:
<img width="685" height="134" alt="Screenshot 2026-07-06 at 2 49 15 PM" src="https://github.com/user-attachments/assets/f6c80f4d-0245-4709-a8f0-7f6b55fb2d9f" />

<img width="559" height="757" alt="Screenshot 2026-07-06 at 2 06 18 PM" src="https://github.com/user-attachments/assets/47ebd8c0-344e-4b45-873c-a28f1e3cd7da" />

<img width="559" height="720" alt="Screenshot 2026-07-06 at 2 08 48 PM" src="https://github.com/user-attachments/assets/c0f8cdc7-cc09-4653-9884-8bf497aec123" />

## Master Issue
Closes https://rokt.atlassian.net/browse/SDKE-1210
