### PR TITLE
fix(ios): register RoktEventManager as a TurboModule so events survive bridgeless

### DIFF
--- a/ios/RNMParticle.xcodeproj/project.pbxproj
+++ b/ios/RNMParticle.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		B39BCD8F2E2A06D700FC90B8 /* RoktEventManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B39BCD8C2E2A06D700FC90B8 /* RoktEventManager.m */; };
+		B39BCD8F2E2A06D700FC90B8 /* RoktEventManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = B39BCD8C2E2A06D700FC90B8 /* RoktEventManager.mm */; };
 		B39BCD962E30562400FC90B8 /* RoktLayoutManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B39BCD932E30562400FC90B8 /* RoktLayoutManager.m */; };
 		B39BCD972E30562400FC90B8 /* RNMPRokt.mm in Sources */ = {isa = PBXBuildFile; fileRef = B39BCD922E30562400FC90B8 /* RNMPRokt.mm */; };
 		B39BCD982E30562400FC90B8 /* RNMParticle.mm in Sources */ = {isa = PBXBuildFile; fileRef = B39BCD912E30562400FC90B8 /* RNMParticle.mm */; };
@@ -31,7 +31,7 @@
 /* Begin PBXFileReference section */
 		B39BCD892E2A06D700FC90B8 /* RNMPRokt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNMPRokt.h; sourceTree = "<group>"; };
 		B39BCD8B2E2A06D700FC90B8 /* RoktEventManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RoktEventManager.h; sourceTree = "<group>"; };
-		B39BCD8C2E2A06D700FC90B8 /* RoktEventManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RoktEventManager.m; sourceTree = "<group>"; };
+		B39BCD8C2E2A06D700FC90B8 /* RoktEventManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RoktEventManager.mm; sourceTree = "<group>"; };
 		B39BCD912E30562400FC90B8 /* RNMParticle.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RNMParticle.mm; sourceTree = "<group>"; };
 		B39BCD922E30562400FC90B8 /* RNMPRokt.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RNMPRokt.mm; sourceTree = "<group>"; };
 		B39BCD932E30562400FC90B8 /* RoktLayoutManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RoktLayoutManager.m; sourceTree = "<group>"; };
@@ -78,7 +78,7 @@
 				B39BCD952E30562400FC90B8 /* RoktNativeLayoutComponentView.mm */,
 				B39BCD892E2A06D700FC90B8 /* RNMPRokt.h */,
 				B39BCD8B2E2A06D700FC90B8 /* RoktEventManager.h */,
-				B39BCD8C2E2A06D700FC90B8 /* RoktEventManager.m */,
+				B39BCD8C2E2A06D700FC90B8 /* RoktEventManager.mm */,
 				DBDF24DA1E007EB1000F3D73 /* RNMParticle.h */,
 			);
 			path = RNMParticle;
@@ -146,7 +146,7 @@
 				B39BCD972E30562400FC90B8 /* RNMPRokt.mm in Sources */,
 				B39BCD982E30562400FC90B8 /* RNMParticle.mm in Sources */,
 				B39BCD992E30562400FC90B8 /* RoktNativeLayoutComponentView.mm in Sources */,
-				B39BCD8F2E2A06D700FC90B8 /* RoktEventManager.m in Sources */,
+				B39BCD8F2E2A06D700FC90B8 /* RoktEventManager.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/RNMParticle/RoktEventManager.h
+++ b/ios/RNMParticle/RoktEventManager.h
@@ -1,11 +1,25 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
 
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <RNMParticle/RNMParticle.h>
+#endif // RCT_NEW_ARCH_ENABLED
+
 @class RoktEvent;
 
 NS_ASSUME_NONNULL_BEGIN
 
+// Conforms to the codegen'd spec under the New Architecture so the emitter is
+// registered as a TurboModule. Without it this class is a plain RCTBridgeModule,
+// which bridgeless only instantiates when the host app enables TurboModule interop
+// -- otherwise NativeModules.RoktEventManager is undefined and every Rokt event is
+// dropped before reaching JS.
+#ifdef RCT_NEW_ARCH_ENABLED
+@interface RoktEventManager : RCTEventEmitter <RCTBridgeModule, NativeRoktEventManagerSpec>
+#else
 @interface RoktEventManager : RCTEventEmitter <RCTBridgeModule>
+#endif // RCT_NEW_ARCH_ENABLED
+
 + (instancetype _Nonnull)allocWithZone:(NSZone * _Nullable)zone;
 - (void)onWidgetHeightChanges:(CGFloat)widgetHeight placement:(NSString * _Nonnull)selectedPlacement;
 - (void)onFirstPositiveResponse;

--- a/ios/RNMParticle/RoktEventManager.mm
+++ b/ios/RNMParticle/RoktEventManager.mm
@@ -1,5 +1,11 @@
 #import "RoktEventManager.h"
-@import RoktContracts;
+// Not `@import RoktContracts` -- this file is Objective-C++ and the pod builds without
+// -fcxx-modules, so the module import fails. Matches how RNMPRokt.mm imports the same types.
+#if __has_include(<RoktContracts/RoktContracts-Swift.h>)
+    #import <RoktContracts/RoktContracts-Swift.h>
+#elif __has_include(<RoktContracts/RoktContracts.h>)
+    #import <RoktContracts/RoktContracts.h>
+#endif
 #import <os/log.h>
 
 static os_log_t _rokt_events_os_log(void) {
@@ -232,5 +238,11 @@ RCT_EXPORT_MODULE(RoktEventManager);
          [self sendEventWithName:@"RoktEvents" body:payload];
      }
 }
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const facebook::react::ObjCTurboModule::InitParams &)params {
+    return std::make_shared<facebook::react::NativeRoktEventManagerSpecJSI>(params);
+}
+#endif // RCT_NEW_ARCH_ENABLED
 
 @end

--- a/js/__tests__/attribute-normalization.test.ts
+++ b/js/__tests__/attribute-normalization.test.ts
@@ -12,6 +12,7 @@ jest.mock(
     Platform: { OS: 'ios' },
     TurboModuleRegistry: {
       getEnforcing: jest.fn(() => mockNativeModule),
+      get: jest.fn(() => null),
     },
   }),
   { virtual: true }

--- a/js/__tests__/rokt-event-manager.test.ts
+++ b/js/__tests__/rokt-event-manager.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The Rokt event emitter is an `RCTEventEmitter`, which conforms only to `RCTBridgeModule`.
+ * Bridgeless does not instantiate those unless the host app enabled TurboModule interop, so
+ * resolving it purely through `NativeModules` left it undefined and dropped every Rokt event
+ * before it reached JS. It is now registered via codegen and must be resolved through the
+ * TurboModule registry first, with a `NativeModules` fallback for the old architecture.
+ */
+
+function loadRoktEventManager(
+  turboModule: unknown,
+  nativeModules: Record<string, unknown>
+) {
+  jest.resetModules();
+  jest.doMock(
+    'react-native',
+    () => ({
+      NativeModules: nativeModules,
+      TurboModuleRegistry: { get: jest.fn(() => turboModule) },
+    }),
+    { virtual: true }
+  );
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require('../rokt/rokt-event-manager').RoktEventManager;
+}
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+describe('RoktEventManager resolution', () => {
+  it('resolves through the TurboModule registry when NativeModules has no entry', () => {
+    const turboModule = { addListener: jest.fn(), removeListeners: jest.fn() };
+
+    expect(loadRoktEventManager(turboModule, {})).toBe(turboModule);
+  });
+
+  it('prefers the TurboModule registry over NativeModules', () => {
+    const turboModule = { addListener: jest.fn(), removeListeners: jest.fn() };
+    const legacyModule = { addListener: jest.fn() };
+
+    expect(
+      loadRoktEventManager(turboModule, { RoktEventManager: legacyModule })
+    ).toBe(turboModule);
+  });
+
+  it('falls back to NativeModules on the old architecture', () => {
+    const legacyModule = { addListener: jest.fn() };
+
+    expect(loadRoktEventManager(null, { RoktEventManager: legacyModule })).toBe(
+      legacyModule
+    );
+  });
+
+  it('is null when neither is available, so NativeEventEmitter is not handed undefined', () => {
+    expect(loadRoktEventManager(null, {})).toBeNull();
+  });
+});

--- a/js/__tests__/rokt-layout-view-missing-module.test.tsx
+++ b/js/__tests__/rokt-layout-view-missing-module.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * `RoktEventManager` resolves to `null` when neither the TurboModule registry nor
+ * `NativeModules` has it -- e.g. bridgeless with TurboModule interop disabled and no
+ * old-architecture fallback registered. RN's real `NativeEventEmitter` throws an
+ * invariant in its constructor on iOS when handed a null module, so this mock
+ * reproduces that behavior and pins that mounting `RoktLayoutView` must not hit it.
+ */
+jest.mock(
+  'react',
+  () => {
+    class Component<P, S> {
+      props: P;
+      state!: S;
+      constructor(props: P) {
+        this.props = props;
+      }
+      setState(partial: Partial<S>) {
+        this.state = { ...this.state, ...partial };
+      }
+    }
+    const createElement = (
+      type: unknown,
+      props: Record<string, unknown> | null
+    ) => ({ type, props: props ?? {} });
+    return { __esModule: true, default: { createElement }, Component };
+  },
+  { virtual: true }
+);
+
+jest.mock(
+  'react-native',
+  () => ({
+    StyleSheet: { create: (styles: unknown) => styles },
+    NativeModules: {},
+    // Mirrors RN's real iOS behavior: constructing with a null module throws.
+    NativeEventEmitter: jest.fn((nativeModule: unknown) => {
+      if (nativeModule == null) {
+        throw new Error(
+          '`new NativeEventEmitter()` requires a non-null argument.'
+        );
+      }
+      return { addListener: jest.fn(() => ({ remove: jest.fn() })) };
+    }),
+    requireNativeComponent: jest.fn(() => 'RoktLegacyLayout'),
+    TurboModuleRegistry: { get: jest.fn(() => null), getEnforcing: jest.fn() },
+  }),
+  { virtual: true }
+);
+
+jest.mock(
+  '../codegenSpecs/rokt/RoktLayoutNativeComponent',
+  () => ({ __esModule: true, default: 'RoktNativeLayout' }),
+  { virtual: true }
+);
+
+import { RoktLayoutView } from '../rokt/rokt-layout-view.ios';
+
+describe('RoktLayoutView (ios) when RoktEventManager is unavailable', () => {
+  it('does not throw while mounting', () => {
+    expect(
+      () => new RoktLayoutView({ placeholderName: 'Location1' })
+    ).not.toThrow();
+  });
+
+  it('still renders the native component', () => {
+    const instance = new RoktLayoutView({ placeholderName: 'Location1' });
+    const element = instance.render() as React.ReactElement;
+    expect(element.type).toBe('RoktLegacyLayout');
+  });
+
+  it('unmounts cleanly with the no-op subscription', () => {
+    const instance = new RoktLayoutView({ placeholderName: 'Location1' });
+    expect(() => instance.componentWillUnmount()).not.toThrow();
+  });
+});

--- a/js/__tests__/rokt-layout-view-style.test.tsx
+++ b/js/__tests__/rokt-layout-view-style.test.tsx
@@ -41,7 +41,10 @@ jest.mock(
     NativeModules: { RoktEventManager: {} },
     NativeEventEmitter: jest.fn(() => ({ addListener: mockAddListener })),
     requireNativeComponent: jest.fn(() => 'RoktLegacyLayout'),
-    TurboModuleRegistry: { getEnforcing: jest.fn(() => ({})) },
+    TurboModuleRegistry: {
+      getEnforcing: jest.fn(() => ({})),
+      get: jest.fn(() => null),
+    },
   }),
   { virtual: true }
 );

--- a/js/codegenSpecs/rokt/NativeRoktEventManager.ts
+++ b/js/codegenSpecs/rokt/NativeRoktEventManager.ts
@@ -1,0 +1,20 @@
+import type { TurboModule } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
+
+/**
+ * Event channel for Rokt placement events.
+ *
+ * The native side is an `RCTEventEmitter`, which only conforms to `RCTBridgeModule`.
+ * Under bridgeless that is not enough to be instantiated unless the host app has
+ * opted into TurboModule interop, so this spec exists to register the emitter as a
+ * TurboModule and keep `RoktEvents` reaching JS in every architecture.
+ *
+ * iOS only. Android delivers the same events over `RCTDeviceEventEmitter`, so this
+ * module is absent there and `TurboModuleRegistry.get` returns null by design.
+ */
+export interface Spec extends TurboModule {
+  addListener(eventName: string): void;
+  removeListeners(count: number): void;
+}
+
+export default TurboModuleRegistry.get<Spec>('RoktEventManager');

--- a/js/rokt/rokt-event-manager.ts
+++ b/js/rokt/rokt-event-manager.ts
@@ -1,0 +1,20 @@
+import { NativeModules, TurboModuleRegistry } from 'react-native';
+
+const ROKT_EVENT_MANAGER_MODULE_NAME = 'RoktEventManager';
+
+/**
+ * The native emitter that carries `RoktEvents` and `LayoutHeightChanges` to JS.
+ *
+ * Resolved through the TurboModule registry first: the native class is an
+ * `RCTEventEmitter`, and under bridgeless those are only instantiated when the host app
+ * has enabled TurboModule interop. Registering it via codegen makes it resolvable either
+ * way; without this the module is undefined and every Rokt event is dropped silently.
+ *
+ * Falls back to `NativeModules` for the old architecture, and is null on Android, where
+ * the same events arrive over `RCTDeviceEventEmitter` and `NativeEventEmitter` accepts a
+ * null module.
+ */
+export const RoktEventManager =
+  TurboModuleRegistry.get(ROKT_EVENT_MANAGER_MODULE_NAME) ??
+  NativeModules[ROKT_EVENT_MANAGER_MODULE_NAME] ??
+  null;

--- a/js/rokt/rokt-layout-view.ios.tsx
+++ b/js/rokt/rokt-layout-view.ios.tsx
@@ -46,7 +46,46 @@ const LayoutNativeComponent = (
 // instead of degrading to a placement that never resizes.
 let eventManagerEmitter: NativeEventEmitter | undefined;
 
-function getEventManagerEmitter(): NativeEventEmitter {
+// A subscription-shaped stand-in for when `RoktEventManager` is unavailable. Height
+// updates never arrive, but nothing downstream has to know the difference.
+interface NoopSubscription {
+  remove(): void;
+}
+interface NoopEventEmitter {
+  addListener(
+    eventType: string,
+    listener: (widgetChanges: WidgetChangeEvent) => void
+  ): NoopSubscription;
+}
+const noopSubscription: NoopSubscription = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  remove: () => {},
+};
+const noopEventEmitter: NoopEventEmitter = {
+  addListener: () => noopSubscription,
+};
+
+/**
+ * `RoktEventManager` resolves to `null` when neither the TurboModule registry nor
+ * `NativeModules` has it -- e.g. bridgeless with TurboModule interop disabled and no
+ * old-architecture fallback registered. RN's `NativeEventEmitter` constructor throws
+ * an invariant on iOS in that case (`` `new NativeEventEmitter()` requires a non-null
+ * argument ``), which would crash every screen that mounts a `RoktLayoutView` instead
+ * of just leaving that one placement un-resizable. Guard it here and hand back a
+ * no-op emitter so the view still renders; it just never receives
+ * `LayoutHeightChanges`.
+ */
+let warnedMissingModule = false;
+function getEventManagerEmitter(): NativeEventEmitter | NoopEventEmitter {
+  if (!RoktEventManager) {
+    if (!warnedMissingModule) {
+      warnedMissingModule = true;
+      console.warn(
+        '[ROKT] RoktEventManager native module is unavailable; RoktLayoutView will not receive height updates.'
+      );
+    }
+    return noopEventEmitter;
+  }
   if (!eventManagerEmitter) {
     eventManagerEmitter = new NativeEventEmitter(
       RoktEventManager as NativeModule

--- a/js/rokt/rokt-layout-view.ios.tsx
+++ b/js/rokt/rokt-layout-view.ios.tsx
@@ -81,7 +81,7 @@ function getEventManagerEmitter(): NativeEventEmitter | NoopEventEmitter {
     if (!warnedMissingModule) {
       warnedMissingModule = true;
       console.warn(
-        '[ROKT] RoktEventManager native module is unavailable; RoktLayoutView will not receive height updates.'
+        '[ROKT] RoktEventManager native module is unavailable; RoktLayoutView will not receive Rokt events (including height updates).'
       );
     }
     return noopEventEmitter;

--- a/js/rokt/rokt-layout-view.ios.tsx
+++ b/js/rokt/rokt-layout-view.ios.tsx
@@ -2,15 +2,13 @@ import {
   requireNativeComponent,
   StyleSheet,
   NativeEventEmitter,
-  NativeModules,
   ViewProps,
   NativeModule,
 } from 'react-native';
 import React, { Component } from 'react';
 import { isFabricEnabled } from '../utils/architecture';
 import RoktLayoutNativeComponent from '../codegenSpecs/rokt/RoktLayoutNativeComponent';
-
-const RoktEventManager = NativeModules.RoktEventManager as NativeModule;
+import { RoktEventManager } from './rokt-event-manager';
 
 export interface HeightChangedEvent extends Event {
   height: string;
@@ -43,13 +41,25 @@ const LayoutNativeComponent = (
     : requireNativeComponent<RoktNativeLayoutProps>('RoktLegacyLayout')
 ) as any;
 
-const eventManagerEmitter = new NativeEventEmitter(RoktEventManager);
+// Built on first use rather than at module scope: constructing a NativeEventEmitter with a
+// missing native module throws on iOS, which would take down the bundle at import time
+// instead of degrading to a placement that never resizes.
+let eventManagerEmitter: NativeEventEmitter | undefined;
+
+function getEventManagerEmitter(): NativeEventEmitter {
+  if (!eventManagerEmitter) {
+    eventManagerEmitter = new NativeEventEmitter(
+      RoktEventManager as NativeModule
+    );
+  }
+  return eventManagerEmitter;
+}
 
 export class RoktLayoutView extends Component<
   RoktLayoutViewProps,
   RoktLayoutViewState
 > {
-  subscription = eventManagerEmitter.addListener(
+  subscription = getEventManagerEmitter().addListener(
     'LayoutHeightChanges',
     (widgetChanges: WidgetChangeEvent) => {
       if (widgetChanges.selectedPlacement == this.state.placeholderName) {

--- a/js/rokt/rokt.ts
+++ b/js/rokt/rokt.ts
@@ -1,6 +1,7 @@
 import { NativeModules, Platform, TurboModuleRegistry } from 'react-native';
 import { getNativeModule, isNewArchitecture } from '../utils/architecture';
 import type { Spec as NativeMPRoktInterface } from '../codegenSpecs/rokt/NativeMPRokt';
+import { RoktEventManager } from './rokt-event-manager';
 
 const ROKT_MODULE_NAME = 'RNMPRokt';
 const MPRokt =
@@ -124,8 +125,6 @@ class RoktConfig implements IRoktConfig {
     this.cacheConfig = cacheConfig;
   }
 }
-const { RoktEventManager } = NativeModules;
-
 export { RoktEventManager };
 
 export type ColorMode = 'light' | 'dark' | 'system';


### PR DESCRIPTION
## Background

`RNMPRokt` is a codegen'd TurboModule, but the event channel next to it is not. `RoktEventManager` is a plain `RCTEventEmitter`, and `RCTEventEmitter` conforms only to `RCTBridgeModule` — not `RCTTurboModule`.

Under bridgeless, `RCTTurboModuleManager` decides whether to instantiate an ObjC module like this:

```objc
// RCTTurboModuleManager.mm
- (BOOL)_shouldCreateObjCModule:(Class)moduleClass {
  if (RCTTurboModuleInteropEnabled()) {
    return [moduleClass conformsToProtocol:@protocol(RCTBridgeModule)];
  }
  return [moduleClass conformsToProtocol:@protocol(RCTTurboModule)];
}
```

`useTurboModuleInterop()` defaults to **false** in React Native. It is flipped on by `RCTRootViewFactory.initializeReactHostWithLaunchOptions`, which is the standard `RCTAppDelegate` path — but a brownfield app that drives `RCTHost` itself never goes through it. In that configuration the module is never created, `NativeModules.RoktEventManager` is `undefined`, and:

- `js/rokt/rokt.ts` exported `undefined` as `RoktEventManager`, so an integrator's `new NativeEventEmitter(MParticle.RoktEventManager)` throws the `requires a non-null argument` invariant on iOS;
- `rokt-layout-view.ios.tsx` built that emitter at **module scope**, so the throw happened at import time and took the bundle down rather than degrading;
- when interop *is* on, everything works — which is why this reproduces for some integrators and not others.

The consequence is severe and silent: `selectPlacements` still reaches native, because `RNMPRokt` is a real TurboModule. Placements are selected and served, Rokt's server-side telemetry counts them, but **no `RoktEvents` ever reach JS** — no `InitComplete`, no `PlacementInteractive`, no `PlacementFailure`. Any partner funnel built on those events goes dark while looking like a delivery problem.

Embedded placements fare worse than overlays: `RoktLayoutView` starts at `height: 0` and only grows when `LayoutHeightChanges` arrives, so a dead channel means the placement is selected, served, and **never visible**.

Found while investigating a partner reporting missing placements with zero Rokt events of any type.

## What Has Changed

`RoktEventManager` is now registered through codegen, so it is instantiated in every architecture regardless of the host app's interop setting.

- **New spec** `js/codegenSpecs/rokt/NativeRoktEventManager.ts` declaring `addListener` / `removeListeners`. Uses `TurboModuleRegistry.get` (not `getEnforcing`) because the module is iOS-only.
- **`ios/RNMParticle/RoktEventManager.h`** — conforms to the generated `NativeRoktEventManagerSpec` under `RCT_NEW_ARCH_ENABLED`. Both required selectors are already declared publicly by `RCTEventEmitter`, so no method implementations were needed.
- **`RoktEventManager.m` → `.mm`** — adds `getTurboModule:` returning `NativeRoktEventManagerSpecJSI`, matching the pattern `RNMPRokt.mm` already uses. Xcode project references updated; the podspec glob already covered `.mm`.
- **New `js/rokt/rokt-event-manager.ts`** — single source of truth for resolution: TurboModule registry first, `NativeModules` fallback for the old architecture, `null` otherwise. Extracted rather than inlined so `rokt-layout-view.ios.tsx` does not have to pull in `rokt.ts`'s whole module graph.
- **`rokt-layout-view.ios.tsx`** — emitter is now built lazily instead of at module scope, so a missing module can never fail at import time.

Emission itself is unchanged. `sendEventWithName:` needs `callableJSModules`, and `RCTTurboModuleManager._createAndSetUpObjCModule` calls `[_bridgeModuleDecorator attachInteropAPIsToModule:]` for **every** ObjC module it creates — not just interop ones — and `RCTEventEmitter` synthesises that property. Verified in RN 0.81 source.

No public API change: `MParticle.RoktEventManager` is still exported and still an event-emitter-compatible module. Android is untouched — it delivers the same events over `RCTDeviceEventEmitter` and has no such native module, which is why resolution deliberately tolerates `null`.

## How Has This Been Tested

- **New `js/__tests__/rokt-event-manager.test.ts`** — four cases pinning the resolution order: TurboModule registry alone, registry preferred over `NativeModules`, `NativeModules` fallback for the old architecture, and `null` when neither exists so `NativeEventEmitter` is never handed `undefined`.
- Updated the react-native mocks in the two existing suites to expose `TurboModuleRegistry.get`.
- `yarn jest` — 3 suites, 17 tests, all passing.
- `tsc --noEmit` — clean.
- `eslint` — clean.
- **Codegen verified end to end**: ran `combine-js-to-schema-cli` + `generate-all` against `js/codegenSpecs` and confirmed the new module appears in the schema and that the generated `RNMParticle.h` emits exactly the symbols the native code references:

```objc
@protocol NativeRoktEventManagerSpec <RCTBridgeModule, RCTTurboModule>
- (void)addListener:(NSString *)eventName;
- (void)removeListeners:(double)count;
@end
// class JSI_EXPORT NativeRoktEventManagerSpecJSI : public ObjCTurboModule
```

## Notes

Worth a reviewer's judgement: this makes `RoktEventManager` instantiate when `js/rokt/rokt-event-manager.ts` is first imported, which happens via `index.tsx`. Previously the `NativeModules` proxy also resolved at module scope, so the timing is equivalent — but integrators who deliberately keep native bridging off the bundle-eval path may care.


## Verified on simulator

Reproduced the failure and confirmed the fix on an iPhone 16 Pro simulator (iOS 18.6), RN 0.84, bridgeless. Only variable changed between the two runs is the SDK version; app, probe and configuration are identical.

To reproduce the failing condition the sample app disables TurboModule interop from its own `AppDelegate` after `[super application:...]` returns, simulating a brownfield host that never goes through `RCTRootViewFactory`. `RCTRootViewFactory` enables interop unconditionally in bridgeless, so the stock sample app cannot exhibit this. The interop state is logged directly (`LABFLAG`) so the result is not inferred.

**Before (this branch's parent):**

```
LABFLAG interopEnabled=0 bridgeProxy=0

native:  [mParticle-Rokt] RNMPRokt module load
         (RoktEventManager module alloc)      <- absent
         (RoktEventManager startObserving)    <- absent

js:      Invariant Violation: `new NativeEventEmitter()` requires a non-null argument.
         Invariant Violation: "MParticleSample" has not been registered.
```

`RoktEventManager` is never instantiated, so JS receives `undefined`. Because the layout view built its emitter at module scope, the throw happened during import and prevented `AppRegistry.registerComponent` from running — the app failed to start entirely, rather than merely losing events.

**After (this branch):**

```
LABFLAG interopEnabled=0 bridgeProxy=0

native:  [mParticle-Rokt] RNMPRokt module load
         [mParticle-Rokt] RoktEventManager module alloc
         [mParticle-Rokt] RoktEventManager startObserving (JS listener added)

js:      NativeModules.RoktEventManager=DEFINED
         TurboModuleRegistry.get=DEFINED
         resolved=DEFINED
         NativeEventEmitter=CONSTRUCTED
         addListener=OK
         (no exceptions)
```

The module is created, resolves from JS, and a JS listener reaches native — confirmed on both sides of the bridge.

This matches the mechanism in RN source: `RCTTurboModuleManager.mm` installs `legacyModuleProvider` only when interop is enabled, and in bridgeless `__turboModuleProxy` is never installed, so a legacy `RCTEventEmitter` is unreachable from JS without it. Registering the emitter via codegen removes that dependency.
