### PR TITLE
fix: Map All Commerce Fields on iOS New Architecture

### DIFF
--- a/ios/RNMParticle/RNMParticle.mm
+++ b/ios/RNMParticle/RNMParticle.mm
@@ -23,11 +23,17 @@
 + (NSDictionary *)consentStateToDictionary:(MPConsentState *)consentState;
 @end
 
+@interface RNMParticle (CommerceMapping)
+- (void)applyCommerceEventMetadata:(MPCommerceEvent *)event fromDictionary:(NSDictionary *)dict;
+- (void)addPromotionsFromDicts:(NSArray *)promotionDicts toCommerceEvent:(MPCommerceEvent *)event;
+@end
+
 // Forward declare so New Arch `logCommerceEvent` can use the same JS→native
 // mappings as `RCTConvert (MPCommerceEvent)` (defined later in this file).
 @interface RCTConvert (MPCommerceEvent)
 + (MPCommerceEventAction)MPCommerceEventAction:(id)json;
 + (MPPromotionAction)MPPromotionAction:(id)json;
++ (MPPromotion *)MPPromotion:(id)json;
 + (MPConsentState *)MPConsentState:(id)json;
 @end
 
@@ -544,6 +550,21 @@ RCT_EXPORT_METHOD(getSession:(RCTResponseSenderBlock)completion)
             [RCTConvert MPPromotionAction:@(commerceEvent.promotionActionType().value())];
         mpCommerceEvent.promotionContainer =
             [[MPPromotionContainer alloc] initWithAction:promotionAction promotion:nil];
+
+        if (commerceEvent.promotions().has_value()) {
+            auto promotionsVector = commerceEvent.promotions().value();
+            NSMutableArray *promotionDicts = [[NSMutableArray alloc] init];
+            for (size_t i = 0; i < promotionsVector.size(); i++) {
+                auto promotionStruct = promotionsVector[i];
+                NSMutableDictionary *promotionDict = [[NSMutableDictionary alloc] init];
+                if (promotionStruct.id_()) promotionDict[@"id"] = promotionStruct.id_();
+                if (promotionStruct.name()) promotionDict[@"name"] = promotionStruct.name();
+                if (promotionStruct.creative()) promotionDict[@"creative"] = promotionStruct.creative();
+                if (promotionStruct.position()) promotionDict[@"position"] = promotionStruct.position();
+                [promotionDicts addObject:promotionDict];
+            }
+            [self addPromotionsFromDicts:promotionDicts toCommerceEvent:mpCommerceEvent];
+        }
     }
 
     if (commerceEvent.products().has_value()) {
@@ -635,6 +656,17 @@ RCT_EXPORT_METHOD(getSession:(RCTResponseSenderBlock)completion)
         mpCommerceEvent.customAttributes =
             RNMParticleEventAttributes((NSDictionary *)commerceEvent.customAttributes());
     }
+
+    NSMutableDictionary *metadata = [[NSMutableDictionary alloc] init];
+    if (commerceEvent.currency()) metadata[@"currency"] = commerceEvent.currency();
+    if (commerceEvent.checkoutOptions()) metadata[@"checkoutOptions"] = commerceEvent.checkoutOptions();
+    if (commerceEvent.productActionListName()) metadata[@"productActionListName"] = commerceEvent.productActionListName();
+    if (commerceEvent.productActionListSource()) metadata[@"productActionListSource"] = commerceEvent.productActionListSource();
+    if (commerceEvent.screenName()) metadata[@"screenName"] = commerceEvent.screenName();
+    if (commerceEvent.checkoutStep().has_value()) metadata[@"checkoutStep"] = @(commerceEvent.checkoutStep().value());
+    if (commerceEvent.nonInteractive().has_value()) metadata[@"nonInteractive"] = @(commerceEvent.nonInteractive().value());
+    if (commerceEvent.shouldUploadEvent().has_value()) metadata[@"shouldUploadEvent"] = @(commerceEvent.shouldUploadEvent().value());
+    [self applyCommerceEventMetadata:mpCommerceEvent fromDictionary:metadata];
 
     [[MParticle sharedInstance] logEvent:mpCommerceEvent];
 }
@@ -819,6 +851,50 @@ RCT_EXPORT_METHOD(getDeviceConsentState:(RCTResponseSenderBlock)callback)
     }
 
     return product;
+}
+
+- (void)applyCommerceEventMetadata:(MPCommerceEvent *)event fromDictionary:(NSDictionary *)dict {
+    if (event == nil || ![dict isKindOfClass:[NSDictionary class]]) {
+        return;
+    }
+
+    if (dict[@"checkoutOptions"] && dict[@"checkoutOptions"] != [NSNull null]) {
+        event.checkoutOptions = dict[@"checkoutOptions"];
+    }
+    if (dict[@"currency"] && dict[@"currency"] != [NSNull null]) {
+        event.currency = dict[@"currency"];
+    }
+    if (dict[@"productActionListName"] && dict[@"productActionListName"] != [NSNull null]) {
+        event.productListName = dict[@"productActionListName"];
+    }
+    if (dict[@"productActionListSource"] && dict[@"productActionListSource"] != [NSNull null]) {
+        event.productListSource = dict[@"productActionListSource"];
+    }
+    if (dict[@"screenName"] && dict[@"screenName"] != [NSNull null]) {
+        event.screenName = dict[@"screenName"];
+    }
+    if (dict[@"checkoutStep"] && dict[@"checkoutStep"] != [NSNull null]) {
+        event.checkoutStep = [dict[@"checkoutStep"] intValue];
+    }
+    if (dict[@"nonInteractive"] && dict[@"nonInteractive"] != [NSNull null]) {
+        event.nonInteractive = [dict[@"nonInteractive"] boolValue];
+    }
+    if (dict[@"shouldUploadEvent"] && dict[@"shouldUploadEvent"] != [NSNull null]) {
+        event.shouldUploadEvent = [dict[@"shouldUploadEvent"] boolValue];
+    }
+}
+
+- (void)addPromotionsFromDicts:(NSArray *)promotionDicts toCommerceEvent:(MPCommerceEvent *)event {
+    if (event.promotionContainer == nil || ![promotionDicts isKindOfClass:[NSArray class]]) {
+        return;
+    }
+
+    for (id promotionJSON in promotionDicts) {
+        MPPromotion *promotion = [RCTConvert MPPromotion:promotionJSON];
+        if (promotion) {
+            [event.promotionContainer addPromotion:promotion];
+        }
+    }
 }
 
 - (MPIdentityApiRequest *)MPIdentityApiRequestFromDict:(NSDictionary *)dict {

--- a/sample/ios/MParticleSampleTests/RCTConvertCommerceMappingTests.m
+++ b/sample/ios/MParticleSampleTests/RCTConvertCommerceMappingTests.m
@@ -22,6 +22,8 @@
 
 @interface RNMParticle (ProductMappingTests)
 - (MPProduct *)createMPProductFromDict:(NSDictionary *)productDict;
+- (void)applyCommerceEventMetadata:(MPCommerceEvent *)event fromDictionary:(NSDictionary *)dict;
+- (void)addPromotionsFromDicts:(NSArray *)promotionDicts toCommerceEvent:(MPCommerceEvent *)event;
 @end
 
 /**
@@ -32,8 +34,9 @@
  * JSON → `MPCommerceEvent` tests below exercise the same `+[RCTConvert MPCommerceEvent:]` pipeline
  * used to assemble an `MPCommerceEvent` before `-[MParticle logCommerceEvent:]` (legacy bridge path),
  * including `MPPromotionContainer:` wiring. That catches regressions such as casting JS ints in
- * those helpers instead of calling the mappers. Product tests invoke the helper used by the New
- * Architecture codegen struct path without requiring generated C++ values in this target.
+ * those helpers instead of calling the mappers. Product and commerce-metadata tests invoke the
+ * helpers used by the New Architecture codegen struct path without requiring generated C++ values
+ * in this target.
  */
 @interface RCTConvertCommerceMappingTests : XCTestCase
 @end
@@ -179,6 +182,84 @@
     MPCommerceEvent *clickEvent = [RCTConvert MPCommerceEvent:jsonClick];
     XCTAssertNotNil(clickEvent.promotionContainer);
     XCTAssertEqual(clickEvent.promotionContainer.action, MPPromotionActionClick);
+}
+
+- (void)testMPCommerceEventFromJSON_mapsCurrencyCheckoutStepAndCheckoutOptions
+{
+    NSDictionary *json = @{
+        @"productActionType" : @(3), // Checkout in js/index.tsx
+        @"products" : @[ [self minimalProductJSON] ],
+        @"impressions" : @[],
+        @"currency" : @"USD",
+        @"checkoutStep" : @1,
+        @"checkoutOptions" : @"Visa",
+        @"productActionListName" : @"checkout-list",
+        @"productActionListSource" : @"app",
+        @"screenName" : @"Checkout",
+        @"nonInteractive" : @YES,
+        @"shouldUploadEvent" : @NO,
+    };
+
+    MPCommerceEvent *event = [RCTConvert MPCommerceEvent:json];
+    XCTAssertEqualObjects(event.currency, @"USD");
+    XCTAssertEqual(event.checkoutStep, 1);
+    XCTAssertEqualObjects(event.checkoutOptions, @"Visa");
+    XCTAssertEqualObjects(event.productListName, @"checkout-list");
+    XCTAssertEqualObjects(event.productListSource, @"app");
+    XCTAssertEqualObjects(event.screenName, @"Checkout");
+    XCTAssertTrue(event.nonInteractive);
+    XCTAssertFalse(event.shouldUploadEvent);
+}
+
+- (void)testApplyCommerceEventMetadata_copiesNativeCommerceFieldsForNewArchitecture
+{
+    RNMParticle *module = [[RNMParticle alloc] init];
+    MPCommerceEvent *event = [[MPCommerceEvent alloc] initWithAction:MPCommerceEventActionCheckout];
+
+    [module applyCommerceEventMetadata:event
+                        fromDictionary:@{
+                            @"currency" : @"USD",
+                            @"checkoutStep" : @1,
+                            @"checkoutOptions" : @"Visa",
+                            @"productActionListName" : @"checkout-list",
+                            @"productActionListSource" : @"app",
+                            @"screenName" : @"Checkout",
+                            @"nonInteractive" : @YES,
+                            @"shouldUploadEvent" : @NO,
+                        }];
+
+    XCTAssertEqualObjects(event.currency, @"USD");
+    XCTAssertEqual(event.checkoutStep, 1);
+    XCTAssertEqualObjects(event.checkoutOptions, @"Visa");
+    XCTAssertEqualObjects(event.productListName, @"checkout-list");
+    XCTAssertEqualObjects(event.productListSource, @"app");
+    XCTAssertEqualObjects(event.screenName, @"Checkout");
+    XCTAssertTrue(event.nonInteractive);
+    XCTAssertFalse(event.shouldUploadEvent);
+}
+
+- (void)testAddPromotionsFromDicts_fillsPromotionContainerForNewArchitecture
+{
+    RNMParticle *module = [[RNMParticle alloc] init];
+    MPCommerceEvent *event = [[MPCommerceEvent alloc] init];
+    event.promotionContainer = [[MPPromotionContainer alloc] initWithAction:MPPromotionActionView promotion:nil];
+
+    [module addPromotionsFromDicts:@[
+        @{
+            @"id" : @"promo-1",
+            @"name" : @"Sale",
+            @"creative" : @"banner",
+            @"position" : @"home-top",
+        }
+    ]
+                  toCommerceEvent:event];
+
+    XCTAssertEqual(event.promotionContainer.promotions.count, 1);
+    MPPromotion *promotion = event.promotionContainer.promotions.firstObject;
+    XCTAssertEqualObjects(promotion.promotionId, @"promo-1");
+    XCTAssertEqualObjects(promotion.name, @"Sale");
+    XCTAssertEqualObjects(promotion.creative, @"banner");
+    XCTAssertEqualObjects(promotion.position, @"home-top");
 }
 
 @end


### PR DESCRIPTION
## Summary
On iOS with the New Architecture, commerce fields set in JS were dropped before they reached the native mParticle SDK. setCurrency("USD") produced currency_code: null, and setCheckoutStep(1) produced checkout_step: 0. The same JS worked on Android and on iOS Old Architecture.

The JS layer already stored and forwarded these fields. Android convertCommerceEvent and iOS +[RCTConvert MPCommerceEvent:] (legacy bridge) already mapped them. The TurboModule logCommerceEvent: in ios/RNMParticle/RNMParticle.mm built an MPCommerceEvent from the codegen struct but never copied currency, checkout step, or several related native fields, so the SDK kept defaults.

This change brings the New Architecture path to parity with RCTConvert without routing the whole event through RCTConvert (product/impression conversion still uses createMPProductFromDict).
- Copies optional metadata onto MPCommerceEvent when present: currency, checkoutStep, checkoutOptions, productActionListName / productActionListSource, screenName, nonInteractive, shouldUploadEvent.
- Fills promotionContainer with promotions from the JS struct (it was previously created with promotion: nil and never populated).
- Extracts testable helpers applyCommerceEventMetadata:fromDictionary: and addPromotionsFromDicts:toCommerceEvent:.
- No JS or Android changes. Affected on 3.3.1 / 3.3.2 with New Architecture enabled; there is no JS-only workaround for native currency_code / checkout_step.

## Testing Plan
Sample iOS XCTests in RCTConvertCommerceMappingTests.m:
- Legacy JSON → RCTConvert keeps currency, checkout step, checkout options, list name/source, screen name, nonInteractive, and shouldUploadEvent.
- applyCommerceEventMetadata:fromDictionary: copies the same fields onto an MPCommerceEvent without generated C++ TurboModule types.
- addPromotionsFromDicts:toCommerceEvent: adds a promotion (id, name, creative, position) onto promotionContainer.

Run the MParticleSampleTests target (including RCTConvertCommerceMappingTests) on an iOS simulator.

## Master Issue
Closes https://go.mparticle.com/work/REPLACEME
