### PR TITLE
docs: correct README iOS setup and JS API for 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ React Native allows developers to use a single code base to deploy features to m
 | Identity      | ✓       | ✓   |
 | eCommerce     | ✓       | ✓   |
 | Consent       | ✓       | ✓   |
+| Rokt          | ✓       | ✓   |
 
 # Installation
 
@@ -55,6 +56,14 @@ npx expo install react-native-mparticle
 }
 ```
 
+**Also set the iOS deployment target.** `react-native-mparticle.podspec` requires iOS 15.6 — above React Native's own floor of 15.1 — and this plugin does not set it, so add `expo-build-properties` alongside it (see `ExpoTestApp/app.json`):
+
+```json
+["expo-build-properties", { "ios": { "deploymentTarget": "15.6" } }]
+```
+
+**If you set no `iosKits`, declare the umbrella pod.** On a Swift AppDelegate (Expo SDK 53+) the plugin writes `import mParticle_Apple_SDK`, but nothing installs that pod on its own: this library depends on `mParticle-Apple-SDK-ObjC`, and the umbrella arrives transitively only with a kit (`mParticle-Rokt` depends on `mParticle-Apple-SDK`). Without a kit, add `pod 'mParticle-Apple-SDK', '>= 9.2.2', '< 10.0'` to the generated `ios/Podfile`, and re-apply it after any `expo prebuild --clean`, which rewrites that file. Objective-C templates get `#import "mParticle.h"` instead, which resolves without the umbrella.
+
 3. Run prebuild:
 
 ```bash
@@ -71,21 +80,21 @@ npx expo run:android
 
 ### Plugin Configuration Options
 
-| Option                    | Type     | Required | Description                                                                                   |
-| ------------------------- | -------- | -------- | --------------------------------------------------------------------------------------------- |
-| `iosApiKey`               | string   | Yes      | iOS API key from mParticle dashboard                                                          |
-| `iosApiSecret`            | string   | Yes      | iOS API secret from mParticle dashboard                                                       |
-| `androidApiKey`           | string   | Yes      | Android API key from mParticle dashboard                                                      |
-| `androidApiSecret`        | string   | Yes      | Android API secret from mParticle dashboard                                                   |
-| `logLevel`                | string   | No       | Log level: `'none'`, `'error'`, `'warning'`, `'debug'`, `'verbose'`                           |
-| `environment`             | string   | No       | Environment: `'development'`, `'production'`, `'autoDetect'`                                  |
-| `dataPlanId`              | string   | No       | Data plan ID for validation                                                                   |
-| `dataPlanVersion`         | number   | No       | Data plan version                                                                             |
-| `iosKits`                 | string[] | No       | iOS kit pod names (e.g., `['mParticle-Rokt']`)                                                |
-| `customBaseUrl`           | string   | No       | Custom base URL for global CNAME setup on iOS and Android                                     |
-| `pinningDisabled`         | boolean  | No       | Disable SSL pinning (`MPNetworkOptions` on iOS; `setPinningDisabledInDevelopment` on Android) |
-| `androidKits`             | string[] | No       | Android kit artifact names (e.g., `['android-rokt-kit']`)                                     |
-| `useEmptyIdentifyRequest` | boolean  | No       | Use empty user identify request at init (default: `true`)                                     |
+| Option                    | Type     | Required | Description                                                                                                     |
+| ------------------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| `iosApiKey`               | string   | Yes      | iOS API key from mParticle dashboard                                                                            |
+| `iosApiSecret`            | string   | Yes      | iOS API secret from mParticle dashboard                                                                         |
+| `androidApiKey`           | string   | Yes      | Android API key from mParticle dashboard                                                                        |
+| `androidApiSecret`        | string   | Yes      | Android API secret from mParticle dashboard                                                                     |
+| `logLevel`                | string   | No       | Log level: `'none'`, `'error'`, `'warning'`, `'debug'`, `'verbose'`                                             |
+| `environment`             | string   | No       | Environment: `'development'`, `'production'`, `'autoDetect'`                                                    |
+| `dataPlanId`              | string   | No       | Data plan ID for validation                                                                                     |
+| `dataPlanVersion`         | number   | No       | Data plan version (ignored unless `dataPlanId` is also set)                                                     |
+| `iosKits`                 | string[] | No       | iOS kit pod names (e.g., `['mParticle-Rokt']`)                                                                  |
+| `customBaseUrl`           | string   | No       | Custom base URL for global CNAME setup on iOS and Android; must be an absolute `https://` URL or prebuild fails |
+| `pinningDisabled`         | boolean  | No       | Disable SSL pinning (`MPNetworkOptions` on iOS; `setPinningDisabledInDevelopment` on Android)                   |
+| `androidKits`             | string[] | No       | Android kit artifact names (e.g., `['android-rokt-kit']`)                                                       |
+| `useEmptyIdentifyRequest` | boolean  | No       | Use empty user identify request at init (default: `true`)                                                       |
 
 ### Example with Kits
 
@@ -125,8 +134,8 @@ For global CNAME setup, add the optional shared `customBaseUrl` setting:
 
 - Adds mParticle SDK initialization to `AppDelegate` (supports both Swift and Objective-C)
 - Sets `MPNetworkOptions` (`customBaseURL` and/or `pinningDisabled`) before startup when those plugin options are configured
-- Configures `pre_install` hook in Podfile for dynamic framework linking
-- Adds specified kit pod dependencies
+- Configures `pre_install` hook in Podfile for dynamic framework linking, covering the kit's transitive pods (skipped if the Podfile already mentions `mParticle-Apple-SDK`)
+- Adds specified kit pod dependencies — `mParticle-Rokt` is pinned to `>= 9.3.1, < 10.0`, other kits are added unpinned
 
 **Android:**
 
@@ -139,11 +148,11 @@ For global CNAME setup, add the optional shared `customBaseUrl` setting:
 | Expo SDK | React Native | iOS AppDelegate | Android MainApplication |
 | -------- | ------------ | --------------- | ----------------------- |
 | 53+      | 0.79+        | Swift           | Kotlin                  |
-| 50-52    | 0.73-0.78    | Objective-C++   | Kotlin                  |
-| 49       | 0.72         | Objective-C++   | Java                    |
-| ≤48      | ≤0.71        | Objective-C     | Java                    |
+| 52       | 0.76         | Objective-C++   | Kotlin                  |
 
-The plugin automatically detects the language and generates appropriate code for each platform.
+`package.json` declares React Native `>= 0.76.0` as a peer dependency, so earlier Expo SDKs are below the supported floor. The plugin still contains Objective-C and Java generators for those older templates, but they are outside the supported range.
+
+The plugin generates code for the language Expo reports — `swift`, `objc` or `objcpp` for the AppDelegate, `kt` or `java` for `MainApplication`. Anything else logs a warning and injects nothing.
 
 ---
 
@@ -157,12 +166,20 @@ The plugin automatically detects the language and generates appropriate code for
 
 The npm install step above will automatically include our react framework and the core iOS framework in your project. However depending on your app and its other dependecies you must integrate it in 1 of 3 ways
 
-A. Static Libraries are the React Native default but since mParticle iOS contains swift code you need to add an exception for it in the from of a pre-install command in the Podfile.
+First, set the iOS deployment target to 15.6. `react-native-mparticle.podspec` declares `ios 15.6` / `tvos 15.6`, above React Native's own `min_ios_version_supported` (15.1), so set it explicitly in `ios/Podfile` — along with any app target or extension pinned lower:
 
-```bash
+```ruby
+platform :ios, '15.6'
+```
+
+A. Static Libraries are the React Native default, but the Apple SDK and the Rokt pods contain Swift code, so they need an exception in the form of a pre-install command in the Podfile. Apple SDK 9 split `mParticle-Apple-SDK` into `mParticle-Apple-SDK-ObjC` and `mParticle-Apple-SDK-Swift`, so the list covers both, plus the Rokt kit and its transitive pods:
+
+```ruby
 pre_install do |installer|
   installer.pod_targets.each do |pod|
-    if pod.name == 'mParticle-Apple-SDK'
+    if ['mParticle-Apple-SDK', 'mParticle-Apple-SDK-ObjC',
+        'mParticle-Apple-SDK-Swift', 'mParticle-Rokt', 'Rokt-Widget',
+        'RoktContracts', 'RoktUXHelper', 'DcuiSchema'].include?(pod.name)
       def pod.build_type;
         Pod::BuildType.new(:linkage => :dynamic, :packaging => :framework)
       end
@@ -170,6 +187,8 @@ pre_install do |installer|
   end
 end
 ```
+
+The Expo config plugin generates the same list, including the transitive Rokt pods, from `iosKits`; `sample/ios/Podfile` carries it for a bare app.
 
 Then run the following command
 
@@ -179,10 +198,13 @@ bundle exec pod install
 
 B&C. Frameworks are the default for Swift development and while it isn't preferred by React Native it is supported. Additionally you can define whether the frameworks are built staticly or dynamically.
 
-Update your Podfile to be ready to use dynamically linked frameworks by commenting out the following line
+This reads `USE_FRAMEWORKS` from the environment, so your Podfile needs the block that acts on it (see `sample/ios/Podfile`):
 
-```bash
-# :flipper_configuration => flipper_config,
+```ruby
+linkage = ENV['USE_FRAMEWORKS']
+if linkage != nil
+  use_frameworks! :linkage => linkage.to_sym
+end
 ```
 
 Then run either of the following commands
@@ -209,18 +231,28 @@ The `startWithOptions` method requires an options argument containing your key a
 
 For more help, see [the iOS set up docs](https://docs.mparticle.com/developers/sdk/ios/getting-started/#create-an-input).
 
+> **React Native 0.76+ requires a Fabric dependency provider.** Set it in `application:didFinishLaunchingWithOptions:` before starting mParticle. Without it no third-party Fabric component is registered, so `<RoktLayoutView>` mounts as `RCTUnimplementedViewComponentView` and embedded placements never appear. This fails at runtime, not at build time. See `sample/ios/MParticleSample/AppDelegate.mm`.
+>
+> ```objective-c
+> #import <ReactAppDependencyProvider/RCTAppDependencyProvider.h>
+>
+> self.dependencyProvider = [RCTAppDependencyProvider new];
+> ```
+
+> **If you install no iOS kit, declare the umbrella pod.** `mParticle-Apple-SDK` is now a thin Swift umbrella over `mParticle-Apple-SDK-ObjC`, and this wrapper depends on the ObjC pod directly — so the umbrella is installed only when something else declares it, as `mParticle-Rokt` 9.x does. Without a kit, add `pod 'mParticle-Apple-SDK', '>= 9.2.2', '< 10.0'` (matching this library's own floor) for `import mParticle_Apple_SDK` to resolve, or import `mParticle_Apple_SDK_ObjC` instead.
+
 #### Swift Example
 
 ```swift
 import mParticle_Apple_SDK
 
-func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
         //override point for customization after application launch.
         let mParticleOptions = MParticleOptions(key: "<<<App Key Here>>>", secret: "<<<App Secret Here>>>")
 
         //optional- Please see the Identity page for more information on building this object
-        let request = MPIdentityApiRequest()
+        let request = MPIdentityApiRequest.withEmptyUser()
         request.email = "email@example.com"
         mParticleOptions.identifyRequest = request
         //optional
@@ -229,7 +261,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
         }
         //optional
         mParticleOptions.onAttributionComplete = { (attributionResult, error) in
-                    NSLog(@"Attribution Complete. attributionResults = %@", attributionResult.linkInfo)
+            print("Attribution complete. linkInfo = \(String(describing: attributionResult?.linkInfo))")
         }
 
         // Optional global CNAME setup. Configure before start.
@@ -247,14 +279,14 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 Your import statement should be this:
 
 ```objective-c
-#if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle.h>)
-    #import <mParticle_Apple_SDK/mParticle.h>
-#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle.h>)
-    #import <mParticle_Apple_SDK_NoLocation/mParticle.h>
+#if defined(__has_include) && __has_include(<mParticle_Apple_SDK_ObjC/mParticle.h>)
+    #import <mParticle_Apple_SDK_ObjC/mParticle.h>
 #else
     #import "mParticle.h"
 #endif
 ```
+
+Apple SDK 9 moved the Objective-C headers into the `mParticle_Apple_SDK_ObjC` module. The umbrella `mParticle-Apple-SDK` pod is Swift-only and ships no `mParticle.h`, so `<mParticle_Apple_SDK/mParticle.h>` no longer resolves.
 
 Next, you'll need to start the SDK:
 
@@ -274,9 +306,9 @@ Next, you'll need to start the SDK:
         NSLog(@"Identify complete. userId = %@ error = %@", apiResult.user.userId, error);
     };
     //optional
-    mParticleOptions.onAttributionComplete(MPAttributionResult * _Nullable attributionResult, NSError * _Nullable error) {
-        NSLog(@"Attribution Complete. attributionResults = %@", attributionResult.linkInfo)
-    }
+    mParticleOptions.onAttributionComplete = ^(MPAttributionResult * _Nullable attributionResult, NSError * _Nullable error) {
+        NSLog(@"Attribution Complete. attributionResults = %@", attributionResult.linkInfo);
+    };
 
     // Optional global CNAME setup. Configure before start.
     MPNetworkOptions *networkOptions = [[MPNetworkOptions alloc] init];
@@ -304,10 +336,11 @@ In Expo apps, use `iosKits: ["mParticle-Rokt"]` for standard Rokt placements. Th
 See [MIGRATING.md](./MIGRATING.md) for release-specific migration guidance.
 
 For Android Rokt integrations, including `MParticle.Rokt.*` APIs and
-`RoktLayoutView`, `android-core` and `android-rokt-kit` `6.0.0` or newer are
-required. Apps that include `android-rokt-kit` `6.0.0` must build with
-`compileSdk` 35+ and Android Gradle Plugin 8.6+. Android CNAME setup through
-`customBaseUrl` also requires `android-core` `6.0.0` or newer.
+`RoktLayoutView`, `android-core` and `android-rokt-kit` `6.0.1` or newer are
+required — that is the range this library compiles against. Apps that include
+`android-rokt-kit` must build with `compileSdk` 35+ and Android Gradle Plugin
+8.6+. Android CNAME setup through `customBaseUrl` also requires `android-core`
+`6.0.1` or newer.
 
 See [Identity](http://docs.mparticle.com/developers/sdk/ios/identity/) for more information on supplying an `MPIdentityApiRequest` object during SDK initialization.
 
@@ -366,6 +399,16 @@ class MyApplication : Application() {
 
 > **Warning:** Don't log events in your `Application.onCreate()`. Android may instantiate your `Application` class in the background without your knowledge, including when the user isn't using their device, and lead to unexpected results.
 
+### Android Dependencies
+
+This library exposes `com.mparticle:android-core` as an `api` dependency, so you don't have to declare it. `android-rokt-kit` is `compileOnly` here, so apps using `MParticle.Rokt.*` or `RoktLayoutView` must declare it themselves in `android/app/build.gradle`:
+
+```gradle
+implementation "com.mparticle:android-rokt-kit:[6.0.1, 7.0)"
+```
+
+With the Expo config plugin, list the kit in `androidKits` instead.
+
 # Usage
 
 ## Import the mParticle Module
@@ -399,6 +442,20 @@ MParticle.logCommerceEvent(event);
 Transaction attributes are optional for product actions such as AddToCart.
 Purchase and Refund events must include `TransactionAttributes` with a unique
 transaction ID.
+
+```js
+const transactionAttributes = new MParticle.TransactionAttributes(
+  'Test transaction id'
+).setRevenue(19.99);
+
+const event = MParticle.CommerceEvent.createProductActionEvent(
+  MParticle.ProductActionType.Purchase,
+  [product],
+  transactionAttributes
+);
+
+MParticle.logCommerceEvent(event);
+```
 
 ```js
 const promotion = new MParticle.Promotion(
@@ -445,40 +502,57 @@ the key when the attribute should be absent.
 Because `null` and `""` intentionally produce the same output, use a separate
 boolean or status attribute when analytics must distinguish those states.
 
+## Location
+
+`setLocation` sets the location attached to subsequent events on Android. It is
+a **no-op on iOS** — mParticle Apple SDK 9 removed location support — and logs a
+notice instead.
+
+```js
+MParticle.setLocation(37.7749, -122.4194);
+```
+
+The `setLocation()` builders on GDPR and CCPA consent below are unrelated and
+work on both platforms.
+
 ## User
 
-To set, remove, and get user details, call the `User` or `Identity` methods as follows:
+`User` methods are instance methods. Get the current user from `Identity`, or
+construct a `User` from an MPID you already hold. `getCurrentUser` always
+invokes its callback with a `User`, so check `userId` before writing attributes
+if identity may not have resolved yet:
 
 ```js
-MParticle.User.setUserAttribute('User ID', 'Test key', 'Test value');
+MParticle.Identity.getCurrentUser(currentUser => {
+  currentUser.setUserAttribute('Test key', 'Test value');
+  currentUser.setUserAttribute(
+    MParticle.UserAttributeType.FirstName,
+    'Test first name'
+  );
+  currentUser.setUserAttributeArray('Test key', [
+    'Test value 1',
+    'Test value 2',
+  ]);
+  currentUser.setUserTag('Test value');
+  currentUser.incrementUserAttribute('Test key', 1);
+  currentUser.removeUserAttribute('Test key');
+});
 ```
 
 ```js
-MParticle.User.setUserAttribute(
-  'User ID',
-  MParticle.UserAttributeType.FirstName,
-  'Test first name'
-);
+const user = new MParticle.User(mpid);
 ```
 
-```js
-MParticle.User.setUserAttributeArray('User ID', 'Test key', [
-  'Test value 1',
-  'Test value 2',
-]);
-```
+Reads are callback-based:
 
 ```js
-MParticle.User.setUserTag('User ID', 'Test value');
-```
-
-```js
-MParticle.User.removeUserAttribute('User ID', 'Test key');
-```
-
-```js
-MParticle.Identity.getUserIdentities(userIdentities => {
-  console.debug(userIdentities);
+MParticle.Identity.getCurrentUser(currentUser => {
+  currentUser.getUserAttributes(attributes => console.debug(attributes));
+  currentUser.getUserIdentities(userIdentities =>
+    console.debug(userIdentities)
+  );
+  currentUser.getFirstSeen(firstSeen => console.debug(firstSeen));
+  currentUser.getLastSeen(lastSeen => console.debug(lastSeen));
 });
 ```
 
@@ -502,7 +576,7 @@ request.setUserIdentity(
 
 ```js
 MParticle.Identity.getCurrentUser(currentUser => {
-  console.debug(currentUser.userID);
+  console.debug(currentUser.userId); // or currentUser.getMpid()
 });
 ```
 
@@ -559,7 +633,9 @@ MParticle.Identity.modify(request, (error, userId) => {
 ## Attribution
 
 ```js
-var attributions = MParticle.getAttributions();
+MParticle.getAttributions(attributionResults => {
+  console.debug(attributionResults);
+});
 ```
 
 In order to listen for Attributions asynchronously, you need to set the proper field in `MParticleOptions` as shown in the [Android](#android-manual-setup) or the [iOS](#ios-manual-setup) SDK start examples.
@@ -569,19 +645,108 @@ In order to listen for Attributions asynchronously, you need to set the proper f
 Check if a kit is active
 
 ```js
-var isKitActive = MParticle.isKitActive(kitId);
+MParticle.isKitActive(kitId, isActive => {
+  console.debug(isActive);
+});
 ```
 
 Check and set the SDK's opt out status
 
 ```js
-var isOptedOut = MParticle.getOptOut();
-MParticle.setOptOut(!isOptedOut);
+MParticle.getOptOut(isOptedOut => {
+  MParticle.setOptOut(!isOptedOut);
+});
+```
+
+## Rokt
+
+`MParticle.Rokt.*` needs the native Rokt kit (`mParticle-Rokt` on iOS,
+`android-rokt-kit` on Android), and the platforms fail differently without it.
+On Android the native module is not registered, so the placement and session
+methods reject with `RNMPRokt is unavailable`. On iOS the module is always
+registered, so those calls resolve and silently do nothing — watch the events
+below to tell a missing kit from a placement that did not serve.
+
+```js
+const attributes = { email: 'user@example.com' };
+const cacheConfig = MParticle.Rokt.createCacheConfig(30, attributes);
+const config = MParticle.Rokt.createRoktConfig('system', cacheConfig);
+
+MParticle.Rokt.selectPlacements(
+  'MSDKOverlayLayout',
+  attributes,
+  undefined,
+  config
+);
+```
+
+`selectPlacements`, `selectShoppableAds` and `purchaseFinalized` resolve as soon
+as the request reaches the native kit — they do not wait for the placement, so a
+later native failure does not reject them. `close` and `setSessionId` do wait for
+the native call, and `getSessionId` resolves with the current session ID (or
+`null`), but no Rokt method reports success or failure through its promise —
+watch the events below for the outcome.
+
+For embedded placements, render `RoktLayoutView` and pass its node handle in the
+`placeholders` map, keyed by the same `placeholderName`:
+
+```jsx
+<MParticle.RoktLayoutView ref={this.placeholder1} placeholderName="Location1" />
+```
+
+```js
+import { findNodeHandle } from 'react-native';
+
+const placeholders = { Location1: findNodeHandle(this.placeholder1.current) };
+
+MParticle.Rokt.selectPlacements(
+  'MSDKEmbeddedLayout',
+  attributes,
+  placeholders,
+  config
+);
+```
+
+| Method                                                | Notes                                                 |
+| ----------------------------------------------------- | ----------------------------------------------------- |
+| `selectShoppableAds(identifier, attributes, config?)` | iOS only — logs a warning and does nothing on Android |
+| `purchaseFinalized(placementId, catalogItemId, ok)`   | Both platforms                                        |
+| `close()`                                             | Both platforms                                        |
+| `setSessionId(sessionId)` / `getSessionId()`          | Both platforms                                        |
+
+Rokt callbacks and events are emitted as `RoktCallback` and `RoktEvents` on both
+platforms. `MParticle.RoktEventManager` is an iOS-only native module — on
+Android the same events arrive on React Native's device event emitter:
+
+```js
+import { DeviceEventEmitter, NativeEventEmitter, Platform } from 'react-native';
+
+const emitter =
+  Platform.OS === 'ios'
+    ? new NativeEventEmitter(MParticle.RoktEventManager)
+    : DeviceEventEmitter;
+
+const subscription = emitter.addListener('RoktEvents', event =>
+  console.debug(event)
+);
+```
+
+Engagement signals arrive as an `event` field inside a `RoktEvents` payload
+(for example `FirstPositiveEngagement`), not as separate event names.
+
+## Session and Uploads
+
+```js
+// Session UUID; null on iOS and undefined on Android when there is no session
+MParticle.getSession(session => console.debug(session));
+
+MParticle.setUploadInterval(10); // seconds
+MParticle.upload();
 ```
 
 ## Push Registration
 
-The method `MParticle.logPushRegistration()` accepts 2 parameters. For Android, provide both the `pushToken` and `senderId`. For iOS, provide the push token in the first parameter, and simply pass `null` for the second parameter.
+The method `MParticle.logPushRegistration()` accepts 2 parameters, both typed `string`. On Android the call is dropped unless both `pushToken` and `senderId` are non-empty. On iOS the second parameter is ignored, so pass an empty string.
 
 ### Android
 
@@ -592,7 +757,7 @@ MParticle.logPushRegistration(pushToken, senderId);
 ### iOS
 
 ```js
-MParticle.logPushRegistration(pushToken, null);
+MParticle.logPushRegistration(pushToken, '');
 ```
 
 ## GDPR Consent
@@ -600,7 +765,7 @@ MParticle.logPushRegistration(pushToken, null);
 Add a GDPRConsent
 
 ```js
-var gdprConsent = GDPRConsent()
+var gdprConsent = new MParticle.GDPRConsent()
   .setConsented(true)
   .setDocument('the document')
   .setTimestamp(new Date().getTime()) // optional, native SDK will automatically set current timestamp if omitted
@@ -621,14 +786,14 @@ MParticle.removeGDPRConsentStateWithPurpose('the purpose');
 Add a CCPAConsent
 
 ```js
-var ccpaConsent = CCPAConsent()
+var ccpaConsent = new MParticle.CCPAConsent()
   .setConsented(true)
   .setDocument('the document')
   .setTimestamp(new Date().getTime()) // optional, native SDK will automatically set current timestamp if omitted
   .setLocation('the location')
   .setHardwareId('the hardwareId');
 
-MParticle.addCCPAConsentState(ccpaConsent);
+MParticle.setCCPAConsentState(ccpaConsent);
 ```
 
 Remove CCPAConsent
@@ -636,6 +801,24 @@ Remove CCPAConsent
 ```js
 MParticle.removeCCPAConsentState();
 ```
+
+## Device Consent
+
+Device-based consent is written as one state object and read back whole:
+
+```js
+MParticle.setDeviceConsentState({
+  gdpr: { 'the purpose': gdprConsent },
+  ccpa: ccpaConsent,
+});
+
+MParticle.getDeviceConsentState(consentState => console.debug(consentState));
+
+MParticle.clearDeviceConsentState();
+```
+
+A state with no GDPR purposes and no CCPA consent is stored as no state at all,
+so `getDeviceConsentState` yields `null`.
 
 # License
 


### PR DESCRIPTION
## Summary

The README's setup instructions still described Apple SDK 8 and pre-0.76 React Native, and several
Usage samples could not run as written. Verified the whole file against the 3.x implementation and
fixed what didn't match.

- **iOS setup**: split-SDK `pre_install` list, `mParticle_Apple_SDK_ObjC` import (the `NoLocation`
  variant is gone in 9.x), the iOS 15.6 deployment target, the RN 0.76+ Fabric dependency provider,
  and removal of the Flipper step React Native no longer has.
- **AppDelegate samples**: the Objective-C `onAttributionComplete` was written as a call rather than
  a block assignment; the Swift sample used pre-Swift-4 naming, `MPIdentityApiRequest()` and an
  Objective-C `NSLog`.
- **Usage samples that couldn't work**: `MParticle.User.*` receiver and arity,
  `Identity.getUserIdentities`, `addCCPAConsentState`, and the callback-based
  `getAttributions`/`isKitActive`/`getOptOut` — the opt-out sample always opted users out.
- **Newly documented**: Rokt (`selectPlacements`, `RoktLayoutView`, `RoktEventManager`), device
  consent, session/upload, `TransactionAttributes`, and Android's `compileOnly` Rokt kit.
- Expo Version Support table trimmed to the rows reachable under the declared
  `react-native >= 0.76.0` peer dependency.

Reviewer question: should `logPushRegistration` be retyped to accept `null` for iOS, or is
documenting "pass an empty string" the right call?

## Testing Plan

Docs only, no code changes. Claims and samples were checked against `js/`, `ios/`, `android/`,
`plugin/`, `sample/` and `ExpoTestApp/`, plus the mParticle Apple SDK 9 headers and its own Swift
example. `trunk check --upstream=main` reports no new issues on README.md; `prettier --write` also
normalized the pre-existing plugin-options table padding.
