### PR TITLE
docs: correct Fabric dependency provider requirement to React Native 0.77

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ The `startWithOptions` method requires an options argument containing your key a
 
 For more help, see [the iOS set up docs](https://docs.mparticle.com/developers/sdk/ios/getting-started/#create-an-input).
 
-> **React Native 0.76+ requires a Fabric dependency provider.** Set it in `application:didFinishLaunchingWithOptions:` before starting mParticle. Without it no third-party Fabric component is registered, so `<RoktLayoutView>` mounts as `RCTUnimplementedViewComponentView` and embedded placements never appear. This fails at runtime, not at build time. See `sample/ios/MParticleSample/AppDelegate.mm`.
+> **React Native 0.77+ requires a Fabric dependency provider.** Set it in `application:didFinishLaunchingWithOptions:` before starting mParticle. Without it no third-party Fabric component is registered, so `<RoktLayoutView>` mounts as `RCTUnimplementedViewComponentView` and embedded placements never appear. This fails at runtime, not at build time. See `sample/ios/MParticleSample/AppDelegate.mm`.
 >
 > ```objective-c
 > #import <ReactAppDependencyProvider/RCTAppDependencyProvider.h>

--- a/sample/ios/MParticleSample/AppDelegate.mm
+++ b/sample/ios/MParticleSample/AppDelegate.mm
@@ -20,7 +20,7 @@
   self.moduleName = @"MParticleSample";
   self.initialProps = @{};
 
-  // Required since React Native 0.76. Without it no third-party Fabric component is
+  // Required since React Native 0.77. Without it no third-party Fabric component is
   // registered, so <RoktLayoutView> mounts as RCTUnimplementedViewComponentView and
   // embedded placements resolve no placeholder view.
   self.dependencyProvider = [RCTAppDependencyProvider new];


### PR DESCRIPTION
## Summary

The Fabric dependency provider is required from React Native 0.77, not 0.76.
`RCTDependencyProvider`, the `ReactAppDependencyProvider` pod, and
`RCTAppDelegate.dependencyProvider` are all absent at `v0.76.0` and added at
`v0.77.0`, where `thirdPartyFabricComponents` starts consulting the provider.

Corrects the version in the sample AppDelegate comment and the matching iOS
setup callout in the README, both of which contradicted `MIGRATING.md`. The
`>= 0.76.0` peer dependency floor is a separate claim and is unchanged.

## Testing Plan

Comment and prose only, no code paths touched. Prettier and markdownlint pass
with no new issues.
